### PR TITLE
Support wildcards

### DIFF
--- a/lib/Transformation.ts
+++ b/lib/Transformation.ts
@@ -30,6 +30,8 @@ export function transformAlgebra(expr: Alg.Expression): E.Expression {
       return transformExistence(expr as Alg.ExistenceExpression);
     case types.AGGREGATE:
       return transformAggregate(expr as Alg.AggregateExpression);
+    case types.WILDCARD:
+      return transformWildcard(expr as Alg.WildcardExpression);
     default: throw new Err.InvalidExpressionType(expr);
   }
 }
@@ -58,6 +60,12 @@ function transformTerm(term: Alg.TermExpression): E.Expression {
     case 'BlankNode': return new E.BlankNode(term.term.value);
     default: throw new Err.InvalidTermType(term);
   }
+}
+
+function transformWildcard(term: Alg.WildcardExpression): E.Expression {
+  if (!term.wildcard) { throw new Err.InvalidExpression(term); }
+
+  return new E.NamedNode(term.wildcard.value);
 }
 
 // TODO: Maybe do this with a map?
@@ -108,7 +116,6 @@ export function transformLiteral(lit: RDF.Literal): E.Literal<any> {
     case DT.XSD_NON_POSITIVE_INTEGER:
     case DT.XSD_POSITIVE_INTEGER:
     case DT.XSD_LONG:
-    case DT.XSD_INT:
     case DT.XSD_SHORT:
     case DT.XSD_BYTE:
     case DT.XSD_UNSIGNED_LONG:

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "decimal.js": "^10.2.0",
     "immutable": "^3.8.2",
     "rdf-string": "^1.1.1",
-    "sparqlalgebrajs": "^2.0.0",
+    "sparqlalgebrajs": "^2.1.0",
     "uri-js": "^4.2.2",
     "uuid": "^3.3.2"
   },

--- a/test/evaluators/AggregateEvaluator.test.ts
+++ b/test/evaluators/AggregateEvaluator.test.ts
@@ -22,7 +22,7 @@ function makeAggregate(aggregator: string, distinct = false, separator?: string)
   return {
     type: 'expression',
     expressionType: 'aggregate',
-    aggregator,
+    aggregator: aggregator as any,
     distinct,
     separator,
     expression: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,10 +3608,10 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sparqlalgebrajs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.0.0.tgz#23ae1c15ac21f94d236fc43b1ae0292f60795a96"
-  integrity sha512-HcRm3A1v7mSXBSV89BWlhKNynUZVb0JauL8o43zYAMMigkGK6hnwKV/PIUJuJ1zoEpkPgKrTfsYMKcZmQb6KzA==
+sparqlalgebrajs@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.1.0.tgz#1e56c1308af48378ebf958f602620de8296f4041"
+  integrity sha512-7Au010F8vqLn9nCJUo5M8wnlYBftUwjFLxPt+5MEdFguDAJEfdkGoLdqJQVWZ1H+Dn7lDSqIj29sVWZWJ7jnxw==
   dependencies:
     "@rdfjs/data-model" "^1.1.1"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
This makes sure sparqlee can handle algebra with wildcards in it.

This is required for comunica/comunica#542

This can only happen in 1 specific instance and that is a `count(*)`. That is the only time a wildcard can appear (yay for edge cases). The fix is to convert the wildcard to a namednode('*') which is how wildcards were previously handled. You could also make internal representations of wildcards but that would probably require quite some additional changes (and sparqlee is never going to output a wildcard).