### PR TITLE
Fixes missing bnode custom generator fn in the context

### DIFF
--- a/lib/evaluators/AsyncEvaluator.ts
+++ b/lib/evaluators/AsyncEvaluator.ts
@@ -33,6 +33,7 @@ export class AsyncEvaluator {
 
     const context = {
       now: config.now || new Date(Date.now()),
+      bnode: config.bnode || undefined,
       baseIRI: config.baseIRI || undefined,
       exists: config.exists,
       aggregate: config.aggregate,

--- a/lib/evaluators/SyncEvaluator.ts
+++ b/lib/evaluators/SyncEvaluator.ts
@@ -33,6 +33,7 @@ export class SyncEvaluator {
 
     const context: SyncEvaluatorContext = {
       now: config.now || new Date(Date.now()),
+      bnode: config.bnode || undefined,
       baseIRI: config.baseIRI || undefined,
       exists: config.exists,
       aggregate: config.aggregate,

--- a/test/functions/op.bnode.test.ts
+++ b/test/functions/op.bnode.test.ts
@@ -1,0 +1,16 @@
+import {testAll} from '../util/utils';
+import {AsyncEvaluatorConfig} from '../../';
+import {DataFactory} from 'rdf-data-factory';
+
+const DF = new DataFactory();
+
+describe('evaluations of \'bnode\' with custom blank node generator function', () => {
+  let blankNodeCounter = 0;
+  const config: AsyncEvaluatorConfig = {
+    bnode: (input?: string) => Promise.resolve(DF.blankNode(`${input || 'b'}${blankNodeCounter++}`)),
+  };
+  testAll([
+    'BNODE() = _:b0',
+    'BNODE("hello") = _:hello1',
+  ], config);
+});


### PR DESCRIPTION
While working on https://github.com/comunica/comunica/issues/795 I realized that, although I am passing custom blank node generator functions to `sparqlee`'s evaluators as documented at https://github.com/comunica/sparqlee#bnode, my functions are not being used due to `sparqlee` evaluators not adding `bnode` to the context that is passed around internally.

This PR fixes this issue and adds a dedicated test that ensures usage of the externally-provided `bnode`  function.