### PR TITLE
Preserve original blank nodes when using custom bnode generator functions

### DIFF
--- a/lib/expressions/Term.ts
+++ b/lib/expressions/Term.ts
@@ -43,11 +43,12 @@ export class NamedNode extends Term {
 export class BlankNode extends Term {
   static _nextID = 0;
 
+  value: RDF.BlankNode;
   termType: TermType = 'blankNode';
 
-  constructor(public value: string) {
+  constructor(value: RDF.BlankNode|string) {
     super();
-    this.value = value;
+    this.value = typeof value === 'string' ? DF.blankNode(value) : value;
   }
 
   static nextID() {
@@ -56,7 +57,7 @@ export class BlankNode extends Term {
   }
 
   toRDF(): RDF.Term {
-    return DF.blankNode(this.value);
+    return this.value;
   }
 }
 

--- a/lib/functions/SpecialFunctions.ts
+++ b/lib/functions/SpecialFunctions.ts
@@ -344,7 +344,7 @@ const BNODE = {
 
     if (context.bnode) {
       const bnode = await context.bnode(strInput);
-      return new E.BlankNode(bnode.value);
+      return new E.BlankNode(bnode);
     }
 
     return BNODE_(strInput);
@@ -360,7 +360,7 @@ const BNODE = {
 
     if (context.bnode) {
       const bnode = context.bnode(strInput);
-      return new E.BlankNode(bnode.value);
+      return new E.BlankNode(bnode);
     }
 
     return BNODE_(strInput);


### PR DESCRIPTION
While working on https://github.com/comunica/comunica/issues/795 I realized that using custom `bnode` generator functions (also see https://github.com/comunica/sparqlee/pull/80) does not result in the generated blank nodes being returned by `sparqlee`'s evaluators. 

This PR changes how the `BlankNode` expression works internally, supporting the preservation of the blank node being wrapped into the expression itself and ultimately unwrapped by calling `.toRDF()`.