### PR TITLE
Feature/test async and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,3 +341,6 @@ We also handle type promotion by explicitly coding for it. This is done in the a
 
 Running tests will generate a `test-report.html` in the root dir.
 **TODO** Explain test organizatian and expression tables
+
+Evaluating within a test should be done by calling `generalEvaluate`.
+This will test both sync and async implementation if possible. 

--- a/lib/Transformation.ts
+++ b/lib/Transformation.ts
@@ -14,7 +14,7 @@ import {namedFunctions, regularFunctions, specialFunctions,} from './functions';
 import {AsyncExtensionFunction, AsyncExtensionFunctionCreator} from './evaluators/AsyncEvaluator';
 import {SyncExtensionFunction, SyncExtensionFunctionCreator} from './evaluators/SyncEvaluator';
 
-export type FunctionCreatorConfig = {type: 'sync', creator: SyncExtensionFunctionCreator} |
+type FunctionCreatorConfig = {type: 'sync', creator: SyncExtensionFunctionCreator} |
   {type: 'async', creator: AsyncExtensionFunctionCreator};
 
 export function transformAlgebra(expr: Alg.Expression, creatorConfig: FunctionCreatorConfig): E.Expression {

--- a/lib/Transformation.ts
+++ b/lib/Transformation.ts
@@ -14,7 +14,7 @@ import {namedFunctions, regularFunctions, specialFunctions,} from './functions';
 import {AsyncExtensionFunction, AsyncExtensionFunctionCreator} from './evaluators/AsyncEvaluator';
 import {SyncExtensionFunction, SyncExtensionFunctionCreator} from './evaluators/SyncEvaluator';
 
-type FunctionCreatorConfig = {type: 'sync', creator: SyncExtensionFunctionCreator} |
+export type FunctionCreatorConfig = {type: 'sync', creator: SyncExtensionFunctionCreator} |
   {type: 'async', creator: AsyncExtensionFunctionCreator};
 
 export function transformAlgebra(expr: Alg.Expression, creatorConfig: FunctionCreatorConfig): E.Expression {

--- a/lib/functions/SpecialFunctions.ts
+++ b/lib/functions/SpecialFunctions.ts
@@ -223,7 +223,7 @@ function inRecursiveSync(
   if (args.length === 0) {
     const noErrors = results.every((v) => !v);
     if (noErrors) {
-      bool(false);
+      return bool(false);
     } else {
       throw new Err.InError(results);
     }

--- a/test/functions/extension.test.ts
+++ b/test/functions/extension.test.ts
@@ -3,10 +3,7 @@ import {Notation, testTable} from '../util/TruthTable';
 import * as RDF from 'rdf-js';
 import {NamedNode} from 'rdf-js';
 import {SyncExtensionFunctionCreator} from '../../lib/evaluators/SyncEvaluator';
-import {FunctionCreatorConfig} from '../../lib/Transformation';
 import {DataFactory} from 'rdf-data-factory';
-import { translate } from 'sparqlalgebrajs';
-import {AsyncEvaluator} from '../../lib/evaluators/AsyncEvaluator';
 import {Bindings} from '../../lib/Types';
 import {generalEvaluate, GeneralEvaluationConfig} from '../util/generalEvaluation';
 
@@ -108,13 +105,13 @@ describe('extension functions:', () => {
         return arg;
       };
       const bindings = Bindings({
-        '?o': DF.literal("banaan", stringType)
+        '?o': DF.literal('AppLe', stringType)
       });
       const generalEvaluationConfig: GeneralEvaluationConfig = { type: 'sync', config: { extensionFunctionCreator: creator } };
       const evaluated = await generalEvaluate({
         expression: complexQuery, expectEquality: true, generalEvaluationConfig, bindings
       });
-      expect(evaluated.asyncResult).toEqual(DF.literal("BANAAN", stringType));
+      expect(evaluated.asyncResult).toEqual(DF.literal('APPLE', stringType));
     });
   });
 });

--- a/test/functions/extension.test.ts
+++ b/test/functions/extension.test.ts
@@ -2,6 +2,13 @@ import {bool, dateTime, merge, numeric, str, StringMap, stringToTermPrefix, Term
 import {Notation, testTable} from '../util/TruthTable';
 import * as RDF from 'rdf-js';
 import {NamedNode} from 'rdf-js';
+import {SyncExtensionFunctionCreator} from '../../lib/evaluators/SyncEvaluator';
+import {FunctionCreatorConfig} from '../../lib/Transformation';
+import {DataFactory} from 'rdf-data-factory';
+import { translate } from 'sparqlalgebrajs';
+import {AsyncEvaluator} from '../../lib/evaluators/AsyncEvaluator';
+import {Bindings} from '../../lib/Types';
+import {generalEvaluate, GeneralEvaluationConfig} from '../util/generalEvaluation';
 
 function mapToTerm(map: StringMap): TermMap {
   return Object
@@ -9,8 +16,9 @@ function mapToTerm(map: StringMap): TermMap {
     .reduce((p, k) => ({ ...p, [k]: stringToTermPrefix(map[k]) }), {});
 }
 
-describe('extension function: term-equal', () => {
-  const table = `
+describe('extension functions:', () => {
+  describe('term-equal', () => {
+    const table = `
   3i 3i = true
   3d 3d = true
   3f 3f = true
@@ -33,25 +41,80 @@ describe('extension function: term-equal', () => {
   NaN  3f  = false
   3f   NaN = false
   `;
-  function extensionTermEqual(args: RDF.Term[]) {
-    const resMap = mapToTerm(merge(numeric, str, dateTime, bool));
-    return resMap[String(args[0].equals(args[1]))];
-  }
-  const configBase = {
-    arity: 2,
-    op: '<https://example.org/functions#equal>',
-    aliases: merge(numeric, str, dateTime, bool),
-    notation: Notation.Function,
-  };
-  describe('async evaluation of async equal function', () => {
-    const config = Object.assign(Object.assign({}, configBase), {
-      asyncExtensionFunctionCreator: ((functionNamedNode: NamedNode) => {
-        if (functionNamedNode.value === 'https://example.org/functions#equal') {
-        return (args: RDF.Term[]) => Promise.resolve(extensionTermEqual(args));
+    const extensionTermEqual: SyncExtensionFunctionCreator = (functionNamedNode: NamedNode) => {
+      if (functionNamedNode.value === 'https://example.org/functions#equal') {
+        return (args: RDF.Term[]) => {
+          const resMap = mapToTerm(merge(numeric, str, dateTime, bool));
+          return resMap[String(args[0].equals(args[1]))];
+        };
+      }
+    };
+    const configBase = {
+      arity: 2,
+      op: '<https://example.org/functions#equal>',
+      aliases: merge(numeric, str, dateTime, bool),
+      notation: Notation.Function,
+    };
+
+    describe('Can be evaluated', () => {
+      const generalEvaluationConfig: GeneralEvaluationConfig = { type: 'sync', config: {
+          extensionFunctionCreator: extensionTermEqual,
         }
-      })
+      };
+      const config = Object.assign(Object.assign({}, configBase), { generalEvaluationConfig });
+      testTable({...wrap(config), table});
     });
-    testTable({...wrap(config), table});
+
+    describe('throws error when not providing implementation', () => {
+      const errorTable: (e: string) => string = (e) => `
+  3i 3i = ${e}
+  3d 3d = ${e}
+  3f 3f = ${e}
+
+  3i -5i = ${e}
+  3d -5d = ${e}
+  3f -5f = ${e}
+
+  3i 3f = ${e}
+  3i 3d = ${e}
+  3d 3f = ${e}
+  -0f 0f = ${e}
+
+  INF  INF = ${e}
+  -INF -INF = ${e}
+  INF  3f  = ${e}
+  3f   INF = ${e}
+  INF  NaN = ${e}
+  NaN  NaN = ${e}
+  NaN  3f  = ${e}
+  3f   NaN = ${e}
+  `;
+      const config = Object.assign({}, configBase);
+      testTable({...wrap(config), errorTable: errorTable('Unknown named operator')});
+    });
+    it('upper case', async() => {
+      const complexQuery = `PREFIX func: <http://example.org/functions#>
+        SELECT ?caps WHERE {
+              ?s ?p ?o.
+              BIND (func:to-upper-case(?o) AS ?caps)
+        }`;
+      const DF = new DataFactory();
+      const stringType = DF.namedNode('http://www.w3.org/2001/XMLSchema#string');
+      const creator = (functionNamedNode: NamedNode) => (args: RDF.Term[]) => {
+        const arg = args[0];
+        if (arg.termType === 'Literal' && arg.datatype.equals(DF.literal('', stringType).datatype)) {
+          return DF.literal(arg.value.toUpperCase(), stringType);
+        }
+        return arg;
+      };
+      const bindings = Bindings({
+        '?o': DF.literal("banaan", stringType)
+      });
+      const generalEvaluationConfig: GeneralEvaluationConfig = { type: 'sync', config: { extensionFunctionCreator: creator } };
+      const evaluated = await generalEvaluate({
+        expression: complexQuery, expectEquality: true, generalEvaluationConfig, bindings
+      });
+      expect(evaluated.asyncResult).toEqual(DF.literal("BANAAN", stringType));
+    });
   });
-  // TODO: we should test whether the right error is thrown here. (needs to be implemented when we refactor tests)
 });

--- a/test/functions/op.bnode.test.ts
+++ b/test/functions/op.bnode.test.ts
@@ -1,15 +1,15 @@
 import {testAll} from '../util/utils';
 import {DataFactory} from 'rdf-data-factory';
-import {AsyncEvaluatorConfig} from '../../lib/evaluators/AsyncEvaluator';
+import {SyncEvaluatorConfig} from '../../lib/evaluators/SyncEvaluator';
+
 const DF = new DataFactory();
 
 describe('evaluations of \'bnode\' with custom blank node generator function', () => {
-  let blankNodeCounter = 0;
-  const config: AsyncEvaluatorConfig = {
-    bnode: (input?: string) => Promise.resolve(DF.blankNode(`${input || 'b'}${blankNodeCounter++}`)),
+  const config: SyncEvaluatorConfig = {
+    bnode: (input?: string) => DF.blankNode(`${input || 'b'}cd`),
   };
   testAll([
-    'BNODE() = _:b0',
-    'BNODE("hello") = _:hello1',
-  ], config);
+    'BNODE() = _:bcd',
+    'BNODE("hello") = _:hellocd',
+  ], { type: 'sync', config });
 });

--- a/test/functions/op.division.test.ts
+++ b/test/functions/op.division.test.ts
@@ -1,10 +1,10 @@
-import { error, merge, numeric, wrap } from '../util/Aliases';
+import { merge, numeric, wrap } from '../util/Aliases';
 import { Notation, testTable } from '../util/TruthTable';
 
 const config = {
   arity: 2,
   op: '/',
-  aliases: merge(numeric, error),
+  aliases: merge(numeric),
   notation: Notation.Infix,
 };
 
@@ -32,8 +32,8 @@ describe('evaluation of \'/\' like', () => {
   `;
 
   const errorTable = `
-  0i 0i = error
-  3i 0i = error
+  0i 0i = 'Integer division by 0'
+  3i 0i = 'Integer division by 0'
   `;
 
   testTable({ ...wrap(config), table, errorTable });

--- a/test/functions/op.logicalAnd.test.ts
+++ b/test/functions/op.logicalAnd.test.ts
@@ -20,9 +20,9 @@ describe('evaluation of "&&" like', () => {
   `;
 
   const errorTable = `
-  true  error = error
-  error true  = error
-  error error = error
+  true  error = 'Cannot coerce term to EBV'
+  error true  = 'Cannot coerce term to EBV'
+  error error = 'Cannot coerce term to EBV'
   `;
 
   testTable({ ...wrap(config), table, errorTable });

--- a/test/functions/op.logicalOr.test.ts
+++ b/test/functions/op.logicalOr.test.ts
@@ -20,9 +20,9 @@ describe('evaluation of "||" like', () => {
   `;
 
   const errorTable = `
-  false error = error
-  error false = error
-  error error = error
+  false error = 'Cannot coerce term to EBV'
+  error false = 'Cannot coerce term to EBV'
+  error error = 'Cannot coerce term to EBV'
   `;
 
   testTable({ ...wrap(config), table, errorTable });

--- a/test/functions/op.multiplication.test.ts
+++ b/test/functions/op.multiplication.test.ts
@@ -34,9 +34,9 @@ describe('evaluation of \'*\' like', () => {
   `;
 
   const errorTable = `
-  anyNum error = error
-  error  anyNum   = error
-  error  error = error
+  anyNum error = ''
+  error  anyNum   = ''
+  error  error = ''
   `;
 
   testTable({ ...wrap(config), table, errorTable });

--- a/test/functions/op.subtraction.test.ts
+++ b/test/functions/op.subtraction.test.ts
@@ -32,9 +32,9 @@ describe('evaluation of \'-\' like', () => {
   `;
 
   const errorTable = `
-  anyNum error  = error
-  error  anyNum = error
-  error  error  = error
+  anyNum error  = ''
+  error  anyNum = ''
+  error  error  = 'Argument types not valid'
   `;
 
   testTable({ ...wrap(config), table, errorTable });

--- a/test/misc/Exists.test.ts
+++ b/test/misc/Exists.test.ts
@@ -1,12 +1,14 @@
 import {DataFactory} from 'rdf-data-factory';
-import { evaluate } from '../util/utils';
+import {template} from '../util/utils';
+import {generalEvaluate} from '../util/generalEvaluation';
 
 const DF = new DataFactory();
 
 describe.skip('exists', () => {
-  it('runs with mock existence hooks', () => {
-    return expect(evaluate('EXISTS {?s ?p ?o}'))
-      .resolves
-      .toEqual(DF.literal('true', DF.namedNode('http://www.w3.org/2001/XMLSchema#boolean')));
+  it('runs with mock existence hooks', async() => {
+    const evaluated = await generalEvaluate({
+      expression: template('EXISTS {?s ?p ?o}'), expectEquality: true
+    });
+    expect(evaluated.asyncResult).toEqual(DF.literal('true', DF.namedNode('http://www.w3.org/2001/XMLSchema#boolean')));
   });
 });

--- a/test/spec/iri01.spec.ts
+++ b/test/spec/iri01.spec.ts
@@ -30,7 +30,7 @@ describe('We should respect the iri01 spec', () => {
   testAll([
     'URI("uri") = http://example.org/uri',
     'IRI("iri") = http://example.org/iri',
-  ], { baseIRI: 'http://example.org' });
+  ], { type: 'sync', config: { baseIRI: 'http://example.org' }});
 });
 
 /**

--- a/test/tranformation/transformation.test.ts
+++ b/test/tranformation/transformation.test.ts
@@ -25,61 +25,61 @@ const DF = new DataFactory();
 
 describe('ordering literals', () => {
     it('invalid namedNode', () => {
-        //no namednode, language is also not given
-        let num = int("11");
+        // no namednode, language is also not given
+        const num = int('11');
         num.termType = undefined;
         const res = transformLiteral(num);
         expect(res.strValue).toEqual('11');
         expect(res.typedValue).toEqual(11);
         expect(res.language).toEqual(undefined);
-        expect(res.type).toEqual("integer");
-        //no namednode but language is given
-        num.language = "en";
+        expect(res.type).toEqual('integer');
+        // no namednode but language is given
+        num.language = 'en';
         const res2 = transformLiteral(num);
         expect(res2.strValue).toEqual('11');
         expect(res2.typedValue).toEqual(11);
         expect(res2.language).toEqual(undefined);
-        expect(res2.type).toEqual("integer");
+        expect(res2.type).toEqual('integer');
     });
 
     it('integers type transform', () => {
-        const num = int("11");
+        const num = int('11');
         const res = transformLiteral(num);
         expect(res.strValue).toEqual('11');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("integer");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('integer');
         expect(res.typedValue).toEqual(11);
         expect(res.typeURL.value).toEqual(DT.XSD_INTEGER);
         expect(res.expressionType).toEqual('term');
     });
 
     it('double type transform', () => {
-        const num = double("11");
+        const num = double('11');
         const res = transformLiteral(num);
         expect(res.strValue).toEqual('11');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("double");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('double');
         expect(res.typedValue).toEqual(11);
         expect(res.typeURL.value).toEqual(DT.XSD_DOUBLE);
         expect(res.expressionType).toEqual('term');
     });
     it('decimal type transform', () => {
-        const num = decimal("11");
+        const num = decimal('11');
         const res = transformLiteral(num);
         expect(res.strValue).toEqual('11');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("decimal");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('decimal');
         expect(res.typedValue).toEqual(11);
         expect(res.typeURL.value).toEqual(DT.XSD_DECIMAL);
         expect(res.expressionType).toEqual('term');
     });
 
     it('float type transform', () => {
-        const num = float("11");
+        const num = float('11');
         const res = transformLiteral(num);
         expect(res.strValue).toEqual('11');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("float");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('float');
         expect(res.typedValue).toEqual(11);
         expect(res.typeURL.value).toEqual(DT.XSD_FLOAT);
         expect(res.expressionType).toEqual('term');
@@ -89,23 +89,23 @@ describe('ordering literals', () => {
         const lit = DF.literal('ab', DT.RDF_LANG_STRING);
         const res = transformLiteral(lit);
         expect(res.strValue).toEqual('ab');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("langString");
-        expect(res.typedValue).toEqual("ab");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('langString');
+        expect(res.typedValue).toEqual('ab');
         expect(res.typeURL.value).toEqual(DT.RDF_LANG_STRING);
         expect(res.expressionType).toEqual('term');
     });
 
     it('other type transform', () => {
-        const lit = DF.literal('ab', "othertype");
+        const lit = DF.literal('ab', 'othertype');
         const res = transformLiteral(lit);
         expect(res.strValue).toEqual('ab');
-        expect(res.termType).toEqual("literal");
-        expect(res.type).toEqual("langString");
-        expect(res.typedValue).toEqual("ab");
+        expect(res.termType).toEqual('literal');
+        expect(res.type).toEqual('langString');
+        expect(res.typedValue).toEqual('ab');
         expect(res.typeURL.value).toEqual(DT.RDF_LANG_STRING);
         expect(res.expressionType).toEqual('term');
-        expect(res.language).toEqual("othertype");
+        expect(res.language).toEqual('othertype');
     });
 });
 

--- a/test/util/Aliases.ts
+++ b/test/util/Aliases.ts
@@ -4,6 +4,8 @@ import { stringToTerm } from 'rdf-string';
 import { EvaluationConfig, Notation } from './TruthTable';
 import {AsyncExtensionFunctionCreator} from '../../lib/evaluators/AsyncEvaluator';
 import {SyncExtensionFunctionCreator} from '../../lib/evaluators/SyncEvaluator';
+import {FunctionCreatorConfig} from '../../lib/Transformation';
+import {GeneralEvaluationConfig} from './generalEvaluation';
 
 export type StringMap = { [key: string]: string };
 export type TermMap = { [key: string]: RDF.Term };
@@ -17,17 +19,16 @@ export interface NewEvaluationConfig {
   arity: number;
   aliases: StringMap;
   notation: Notation;
-  asyncExtensionFunctionCreator?: AsyncExtensionFunctionCreator;
-  syncExtensionFunctionCreator?: SyncExtensionFunctionCreator;
+  generalEvaluationConfig?: GeneralEvaluationConfig;
 }
 
 // Temp function, should remove later
 // TODO
 export function wrap(conf: NewEvaluationConfig): EvaluationConfig {
-  const { op, arity, aliases, notation, asyncExtensionFunctionCreator, syncExtensionFunctionCreator } = conf;
+  const { op, arity, aliases, notation, generalEvaluationConfig } = conf;
   const aliasMap = aliases;
   const resultMap = mapToTerm(aliases);
-  return { op, arity, aliasMap, resultMap, notation, asyncExtensionFunctionCreator, syncExtensionFunctionCreator };
+  return { op, arity, aliasMap, resultMap, notation, generalEvaluationConfig };
 }
 
 function mapToTerm(map: StringMap): TermMap {

--- a/test/util/Aliases.ts
+++ b/test/util/Aliases.ts
@@ -2,9 +2,6 @@ import * as RDF from 'rdf-js';
 import { stringToTerm } from 'rdf-string';
 
 import { EvaluationConfig, Notation } from './TruthTable';
-import {AsyncExtensionFunctionCreator} from '../../lib/evaluators/AsyncEvaluator';
-import {SyncExtensionFunctionCreator} from '../../lib/evaluators/SyncEvaluator';
-import {FunctionCreatorConfig} from '../../lib/Transformation';
 import {GeneralEvaluationConfig} from './generalEvaluation';
 
 export type StringMap = { [key: string]: string };

--- a/test/util/TruthTable.ts
+++ b/test/util/TruthTable.ts
@@ -104,7 +104,7 @@ class BinaryTable extends Table<[string, string, string]> {
 
     this.parser.errorTable.forEach((row) => {
       const [left, right, error] = row;
-      const { aliasMap, resultMap, op } = this.def;
+      const { aliasMap, op } = this.def;
       const expr = this.format([op, aliasMap[left], aliasMap[right]]);
       it(`${this.format([op, left, right])} should error`, async() => {
         return expect(generalEvaluate({

--- a/test/util/TruthTable.ts
+++ b/test/util/TruthTable.ts
@@ -1,9 +1,8 @@
 import * as RDF from 'rdf-js';
 
 import { termToString } from 'rdf-string';
-import { evaluate } from '../util/utils';
-import {AsyncExtensionFunctionCreator} from "../../lib/evaluators/AsyncEvaluator";
-import {SyncExtensionFunctionCreator} from "../../lib/evaluators/SyncEvaluator";
+import { template } from './utils';
+import {generalEvaluate, GeneralEvaluationConfig} from './generalEvaluation';
 
 /*
  * Maps short strings to longer RDF term-literals for easy use in making
@@ -43,11 +42,10 @@ export interface EvaluationConfig {
   aliasMap: AliasMap;
   resultMap: ResultMap;
   notation: Notation;
-  asyncExtensionFunctionCreator?: AsyncExtensionFunctionCreator;
-  syncExtensionFunctionCreator?: SyncExtensionFunctionCreator;
+  generalEvaluationConfig?: GeneralEvaluationConfig;
 }
 export type EvaluationTable = EvaluationConfig & {
-  table: string;
+  table?: string;
   errorTable?: string;
 };
 
@@ -96,20 +94,22 @@ class BinaryTable extends Table<[string, string, string]> {
       const [left, right, result] = row;
       const { aliasMap, resultMap, op } = this.def;
       const expr = this.format([op, aliasMap[left], aliasMap[right]]);
-      it(`${this.format([op, left, right])} should return ${result}`, () => {
-        return expect(evaluate(expr, {extensionFunctionCreator: this.def.asyncExtensionFunctionCreator})
-          .then(termToString))
-          .resolves
-          .toEqual(termToString(resultMap[result]));
+      it(`${this.format([op, left, right])} should return ${result}`, async() => {
+        const evaluated = await generalEvaluate({
+          expression: template(expr), expectEquality: true, generalEvaluationConfig: this.def.generalEvaluationConfig
+        });
+        expect(termToString(evaluated.asyncResult)).toEqual(termToString(resultMap[result]));
       });
     });
 
     this.parser.errorTable.forEach((row) => {
       const [left, right, error] = row;
-      const { aliasMap, op } = this.def;
+      const { aliasMap, resultMap, op } = this.def;
       const expr = this.format([op, aliasMap[left], aliasMap[right]]);
-      it(`${this.format([op, left, right])} should error`, () => {
-        return expect(evaluate(expr)).rejects.toThrow(Error);
+      it(`${this.format([op, left, right])} should error`, async() => {
+        return expect(generalEvaluate({
+          expression: template(expr), expectEquality: true, generalEvaluationConfig: this.def.generalEvaluationConfig
+        })).rejects.toThrow(error);
       });
     });
   }
@@ -130,11 +130,11 @@ class UnaryTable extends Table<[string, string]> {
       const [arg, result] = row;
       const { aliasMap, op, resultMap } = this.def;
       const expr = this.format([op, aliasMap[arg]]);
-      it(`${this.format([op, arg])} should return ${result}`, () => {
-        return expect(evaluate(expr)
-          .then(termToString))
-          .resolves
-          .toEqual(termToString(resultMap[result]));
+      it(`${this.format([op, arg])} should return ${result}`, async () => {
+        const evaluated = await generalEvaluate({
+          expression: template(expr), expectEquality: true, generalEvaluationConfig: this.def.generalEvaluationConfig
+        });
+        expect(termToString(evaluated.asyncResult)).toEqual(termToString(resultMap[result]));
       });
     });
 
@@ -143,7 +143,9 @@ class UnaryTable extends Table<[string, string]> {
       const { aliasMap, op } = this.def;
       const expr = this.format([op, aliasMap[arg]]);
       it(`${this.format([op, arg])} should error`, () => {
-        expect(evaluate(expr)).rejects.toThrow(Error);
+        return expect(generalEvaluate({
+          expression: template(expr), expectEquality: true, generalEvaluationConfig: this.def.generalEvaluationConfig
+        })).rejects.toThrow(error);
       });
     });
   }
@@ -158,17 +160,15 @@ class UnaryTable extends Table<[string, string]> {
   }
 }
 
-interface ParserConstructor<RowType extends Row> {
-  new(table: string, errorTable: string): TableParser<RowType>;
-}
+type ParserConstructor<RowType extends Row> = new(table: string, errorTable: string) => TableParser<RowType>;
 
 abstract class TableParser<RowType extends Row> {
   table: RowType[];
   errorTable: RowType[];
 
-  constructor(table: string, errTable?: string) {
+  constructor(table?: string, errTable?: string) {
 
-    this.table = this.splitTable(table).map((row) => this.parseRow(row));
+    this.table = table ? this.splitTable(table).map((row) => this.parseRow(row)) : [];
     this.errorTable = (errTable)
       ? this.splitTable(errTable).map((r) => this.parseRow(r))
       : [];
@@ -186,7 +186,8 @@ abstract class TableParser<RowType extends Row> {
 class BinaryTableParser extends TableParser<[string, string, string]> {
   protected parseRow(row: string): [string, string, string] {
     row = row.trim().replace(/  +/g, ' ');
-    const [left, right, _, result] = row.split(' ');
+    const [left, right, _, result] = row.match(/([^\s']+|'[^']*')+/g)
+      .map(i => i.replace(/'([^']*)'/, '$1'));
     return [left, right, result];
   }
 }
@@ -195,7 +196,8 @@ class UnaryTableParser extends TableParser<[string, string]> {
   protected parseRow(row: string): [string, string] {
     // Trim whitespace and remove double spaces
     row = row.trim().replace(/  +/g, ' ');
-    const [arg, _, result] = row.split(' ');
+    const [arg, _, result] = row.match(/([^\s']+|'[^']*')+/g)
+      .map(i => i.replace(/'([^']*)'/, '$1'));
     return [arg, result];
   }
 }

--- a/test/util/generalEvaluation.ts
+++ b/test/util/generalEvaluation.ts
@@ -1,0 +1,65 @@
+import * as RDF from 'rdf-js';
+import {Bindings} from '../../lib/Types';
+import {AsyncEvaluator, AsyncEvaluatorConfig, AsyncExtensionFunctionCreator} from '../../lib/evaluators/AsyncEvaluator';
+import {SyncEvaluator, SyncEvaluatorConfig, SyncExtensionFunctionCreator} from '../../lib/evaluators/SyncEvaluator';
+import {Algebra as Alg, translate} from 'sparqlalgebrajs';
+import {termToString} from 'rdf-string';
+
+
+export type GeneralEvaluationConfig = {type: 'sync', config: SyncEvaluatorConfig} |
+  {type: 'async', config: AsyncEvaluatorConfig};
+export interface Temp{
+  bindings?: Bindings;
+  expression?: string;
+  generalEvaluationConfig?: GeneralEvaluationConfig;
+  expectEquality?: boolean;
+}
+export async function generalEvaluate(arg: Temp): Promise<{ asyncResult: RDF.Term, syncResult?: RDF.Term }> {
+  const bindings: Bindings = arg.bindings ? arg.bindings : Bindings({});
+  if (arg.generalEvaluationConfig?.type === 'async') {
+    return { asyncResult: await evaluateAsync(arg.expression, bindings, arg.generalEvaluationConfig.config) };
+  }else {
+    const asyncResult = await evaluateAsync(arg.expression,  bindings,
+      syncConfigToAsyncConfig(arg.generalEvaluationConfig?.config));
+    const syncResult = evaluateSync(arg.expression, bindings, arg.generalEvaluationConfig?.config);
+    if (arg.expectEquality) {
+      expect(termToString(asyncResult)).toEqual(termToString(syncResult));
+    }
+    return { asyncResult };
+  }
+}
+function syncConfigToAsyncConfig(config: SyncEvaluatorConfig | undefined): AsyncEvaluatorConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+  const {now, baseIRI, exists, aggregate, bnode, extensionFunctionCreator} = config;
+  const asyncExists = exists ? async(e: Alg.ExistenceExpression, m: Bindings) => exists(e, m) : undefined;
+  const asyncAggregate =  aggregate ? async(expression: Alg.AggregateExpression) => aggregate(expression) : undefined;
+  const asyncBnode = bnode ? async(input?: string) => bnode(input) : undefined;
+  const asyncExtensionFunctionCreator = syncCallbackWrapper(extensionFunctionCreator);
+  return {
+    now, baseIRI, exists: asyncExists, aggregate: asyncAggregate, bnode: asyncBnode,
+    extensionFunctionCreator: asyncExtensionFunctionCreator
+  };
+}
+
+function syncCallbackWrapper(f: SyncExtensionFunctionCreator | undefined): AsyncExtensionFunctionCreator | undefined {
+  if (!f) return undefined;
+  return (namedNode: RDF.NamedNode) => async(args: RDF.Term[]) => f(namedNode)(args);
+}
+
+function parse(query: string) {
+  const sparqlQuery = translate(query);
+  // Extract filter expression from complete query
+  return sparqlQuery.input.expression;
+}
+
+function evaluateAsync(expr: string, bindings: Bindings, config?: AsyncEvaluatorConfig): Promise<RDF.Term> {
+  const evaluator = new AsyncEvaluator(parse(expr), config);
+  return evaluator.evaluate(bindings);
+}
+
+function evaluateSync(expr: string, bindings: Bindings, config?: SyncEvaluatorConfig): RDF.Term {
+  const evaluator = new SyncEvaluator(parse(expr), config);
+  return evaluator.evaluate(bindings);
+}

--- a/test/util/generalEvaluation.ts
+++ b/test/util/generalEvaluation.ts
@@ -8,13 +8,13 @@ import {termToString} from 'rdf-string';
 
 export type GeneralEvaluationConfig = {type: 'sync', config: SyncEvaluatorConfig} |
   {type: 'async', config: AsyncEvaluatorConfig};
-export interface Temp{
+export interface GeneralEvaluationArg {
   bindings?: Bindings;
   expression?: string;
   generalEvaluationConfig?: GeneralEvaluationConfig;
   expectEquality?: boolean;
 }
-export async function generalEvaluate(arg: Temp): Promise<{ asyncResult: RDF.Term, syncResult?: RDF.Term }> {
+export async function generalEvaluate(arg: GeneralEvaluationArg): Promise<{ asyncResult: RDF.Term, syncResult?: RDF.Term }> {
   const bindings: Bindings = arg.bindings ? arg.bindings : Bindings({});
   if (arg.generalEvaluationConfig?.type === 'async') {
     return { asyncResult: await evaluateAsync(arg.expression, bindings, arg.generalEvaluationConfig.config) };


### PR DESCRIPTION
This pull request aims to close [Test both async and sync implementations #36](https://github.com/comunica/sparqlee/issues/36). It also provides a way to say what kind of error should be thrown when calling `testAllError` this by writing `'error string'`. If the type doesn't matter you can write `''`. The pull request also provides [a test that was previously asked for](https://github.com/comunica/sparqlee/pull/85/files/349c8d6b32b2cfd96e5239594ed72c6f5d465541#diff-e5c4a2e03409ea291e9840c4e41c65978d93060262a9bf643eac089ec3139b2f).