### PR TITLE
Speed up new type system when using no cache

### DIFF
--- a/lib/expressions/Expressions.ts
+++ b/lib/expressions/Expressions.ts
@@ -75,7 +75,7 @@ export type SpecialOperatorExpression = IExpressionProps & {
 };
 
 // TODO: Create alias Term = TermExpression
-export function isTermType(type: string): TermType | undefined {
+export function asTermType(type: string): TermType | undefined {
   if (type === 'namedNode' || type === 'literal' || type === 'blankNode') {
     return type;
   }

--- a/lib/util/TypeHandling.ts
+++ b/lib/util/TypeHandling.ts
@@ -1,6 +1,6 @@
 import type * as LRUCache from 'lru-cache';
 import type { TermType } from '../expressions';
-import { isTermType } from '../expressions';
+import { asTermType } from '../expressions';
 import type { ArgumentType } from '../functions';
 import type { KnownLiteralTypes } from './Consts';
 import { TypeAlias, TypeURL } from './Consts';
@@ -186,7 +186,7 @@ export function getSuperTypes(type: string, openWorldType: ISuperTypeProvider): 
     return res;
   }
   let subExtension: GeneralSuperTypeDict;
-  const knownValue = isKnownLiteralType(value);
+  const knownValue = asKnownLiteralType(value);
   if (knownValue) {
     subExtension = { ...superTypeDictTable[knownValue] };
   } else {
@@ -235,29 +235,29 @@ function initTypeAliasCheck(): void {
 }
 initTypeAliasCheck();
 
-export function isTypeAlias(type: string): TypeAlias | undefined {
+export function asTypeAlias(type: string): TypeAlias | undefined {
   if (type in typeAliasCheck) {
     return <TypeAlias> type;
   }
   return undefined;
 }
 
-export function isKnownLiteralType(type: string): KnownLiteralTypes | undefined {
+export function asKnownLiteralType(type: string): KnownLiteralTypes | undefined {
   if (type in superTypeDictTable) {
     return <KnownLiteralTypes> type;
   }
   return undefined;
 }
 
-export function isOverrideType(type: string): OverrideType | undefined {
-  if (isKnownLiteralType(type) || type === 'term') {
+export function asOverrideType(type: string): OverrideType | undefined {
+  if (asKnownLiteralType(type) || type === 'term') {
     return <OverrideType> type;
   }
   return undefined;
 }
 
-export function isGeneralType(type: string): 'term' | TermType | undefined {
-  if (type === 'term' || isTermType(type)) {
+export function asGeneralType(type: string): 'term' | TermType | undefined {
+  if (type === 'term' || asTermType(type)) {
     return <'term' | TermType> type;
   }
   return undefined;
@@ -287,7 +287,7 @@ export function isInternalSubType(baseType: OverrideType, argumentType: KnownLit
  */
 export function isSubTypeOf(baseType: string, argumentType: KnownLiteralTypes,
   openWorldEnabler: ISuperTypeProvider): boolean {
-  const concreteType: OverrideType | undefined = isOverrideType(baseType);
+  const concreteType: OverrideType | undefined = asOverrideType(baseType);
   let subExtensionTable: GeneralSuperTypeDict;
   if (concreteType === 'term' || baseType === 'term') {
     return false;

--- a/test/unit/util/Typehandling.test.ts
+++ b/test/unit/util/Typehandling.test.ts
@@ -3,9 +3,9 @@ import { TypeAlias, TypeURL } from '../../../lib/util/Consts';
 import type { OverrideType } from '../../../lib/util/TypeHandling';
 import {
   isInternalSubType,
-  isKnownLiteralType,
-  isOverrideType, isSubTypeOf,
-  isTypeAlias,
+  asKnownLiteralType,
+  asOverrideType, isSubTypeOf,
+  asTypeAlias,
 } from '../../../lib/util/TypeHandling';
 import { getDefaultSharedContext } from '../../util/utils';
 
@@ -14,7 +14,7 @@ describe('TypeHandling', () => {
     it('can say yes', () => {
       expect(
         [ TypeAlias.SPARQL_NON_LEXICAL, TypeAlias.SPARQL_NUMERIC, TypeAlias.SPARQL_STRINGLY ]
-          .every(type => isTypeAlias(type)),
+          .every(type => asTypeAlias(type)),
       ).toBeTruthy();
     });
     it('can say no', () => {
@@ -22,7 +22,7 @@ describe('TypeHandling', () => {
         [
           '', 'apple', 'not a literal type', 'pear', 'term', TypeURL.XSD_INTEGER, TypeURL.XSD_DECIMAL,
           TypeURL.XSD_BOOLEAN, TypeURL.XSD_DATE_TIME, TypeURL.XSD_DOUBLE, TypeURL.XSD_STRING,
-        ].every(type => !isTypeAlias(type)),
+        ].every(type => !asTypeAlias(type)),
       ).toBeTruthy();
     });
   });
@@ -30,20 +30,20 @@ describe('TypeHandling', () => {
     it('can say yes', () => {
       expect([ TypeURL.XSD_DECIMAL, TypeURL.XSD_DOUBLE, TypeURL.XSD_YEAR_MONTH_DURATION, TypeURL.RDF_LANG_STRING,
         TypeAlias.SPARQL_NUMERIC, TypeAlias.SPARQL_NON_LEXICAL, TypeAlias.SPARQL_NON_LEXICAL ]
-        .every(type => isKnownLiteralType(type))).toBeTruthy();
+        .every(type => asKnownLiteralType(type))).toBeTruthy();
     });
     it('can say no', () => {
-      [ '', 'apple', 'not a literal type', 'pear', 'term' ].every(type => !isKnownLiteralType(type));
+      [ '', 'apple', 'not a literal type', 'pear', 'term' ].every(type => !asKnownLiteralType(type));
     });
   });
   describe('has isOverrideType function', () => {
     it('can say yes', () => {
       expect([ TypeURL.XSD_DECIMAL, TypeURL.XSD_DOUBLE, TypeURL.XSD_YEAR_MONTH_DURATION, TypeURL.RDF_LANG_STRING,
         TypeAlias.SPARQL_NUMERIC, TypeAlias.SPARQL_NON_LEXICAL, TypeAlias.SPARQL_NON_LEXICAL, 'term' ]
-        .every(type => isOverrideType(type))).toBeTruthy();
+        .every(type => asOverrideType(type))).toBeTruthy();
     });
     it('can say no', () => {
-      expect([ '', 'apple', 'not a literal type', 'pear' ].every(type => !isOverrideType(type))).toBeTruthy();
+      expect([ '', 'apple', 'not a literal type', 'pear' ].every(type => !asOverrideType(type))).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
This PR just removes the use of Object.entries in the `getSubTreeWithArg` function. This almost halves the execution time of the new type system when not using a cache or when the cache misses.

It can be seen as a part of #119 and might provide an example of the kind of optimizations we need.