### PR TITLE
Swaps decimal.js for bignumber.js to lower bundle size

### DIFF
--- a/lib/functions/RegularFunctions.ts
+++ b/lib/functions/RegularFunctions.ts
@@ -1,4 +1,4 @@
-import { Decimal } from 'decimal.js';
+import { BigNumber } from 'bignumber.js';
 import { sha1, sha256, sha384, sha512 } from 'hash.js';
 import { DataFactory } from 'rdf-data-factory';
 import { resolve as resolveRelativeIri } from 'relative-to-absolute-iri';
@@ -54,21 +54,21 @@ const unaryMinus = {
 const multiplication = {
   arity: 2,
   overloads: declare(C.RegularOperator.MULTIPLICATION)
-    .arithmetic(() => (left, right) => Decimal.mul(left, right).toNumber())
+    .arithmetic(() => (left, right) => new BigNumber(left).times(right).toNumber())
     .collect(),
 };
 
 const division = {
   arity: 2,
   overloads: declare(C.RegularOperator.DIVISION)
-    .arithmetic(() => (left, right) => Decimal.div(left, right).toNumber())
+    .arithmetic(() => (left, right) => new BigNumber(left).div(right).toNumber())
     .onBinaryTyped(
       [ TypeURL.XSD_INTEGER, TypeURL.XSD_INTEGER ],
       () => (left: number, right: number) => {
         if (right === 0) {
           throw new Err.ExpressionError('Integer division by 0');
         }
-        return decimal(Decimal.div(left, right).toNumber());
+        return decimal(new BigNumber(left).div(right).toNumber());
       },
     )
     .collect(),
@@ -77,14 +77,14 @@ const division = {
 const addition = {
   arity: 2,
   overloads: declare(C.RegularOperator.ADDITION)
-    .arithmetic(() => (left, right) => Decimal.add(left, right).toNumber())
+    .arithmetic(() => (left, right) => new BigNumber(left).plus(right).toNumber())
     .collect(),
 };
 
 const subtraction = {
   arity: 2,
   overloads: declare(C.RegularOperator.SUBTRACTION)
-    .arithmetic(() => (left, right) => Decimal.sub(left, right).toNumber())
+    .arithmetic(() => (left, right) => new BigNumber(left).minus(right).toNumber())
     .collect(),
 };
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/lru-cache": "^5.1.1",
     "@types/spark-md5": "^3.0.2",
     "@types/uuid": "^8.0.0",
-    "decimal.js": "^10.2.0",
+    "bignumber.js": "^9.0.1",
     "hash.js": "^1.1.7",
     "immutable": "^3.8.2",
     "lru-cache": "^6.0.0",


### PR DESCRIPTION
This PR replaces `decimal.js` (32 KB) with `bignumber.js` (20 KB) to lower bundle size. The minimal changes required to make this happen made this a very low-hanging fruit.

A further step along the same direction would be to use either `big.js` (8 KB) or `decimal.js-light` (6 KB). However, doing so requires more work to handle edge cases involving `Infinity`, `NaN` and `-0` as these are not supported by the smaller libraries.