### PR TITLE
Returns a consistent order for uncomparable literals

### DIFF
--- a/lib/util/Ordering.ts
+++ b/lib/util/Ordering.ts
@@ -1,39 +1,36 @@
 import type * as RDF from '@rdfjs/types';
 import * as LRUCache from 'lru-cache';
-import type * as T from '../expressions/Term';
 import { TermTransformer } from '../transformers/TermTransformer';
 import type { ISuperTypeProvider, SuperTypeCallback, TypeCache } from './TypeHandling';
 
 // Determine the relative numerical order of the two given terms.
 export function orderTypes(litA: RDF.Term | undefined, litB: RDF.Term | undefined, isAscending: boolean,
   typeDiscoveryCallback?: SuperTypeCallback, typeCache?: TypeCache, enableExtendedXSDTypes?: boolean): -1 | 0 | 1 {
+  if (litA === undefined || litB === undefined || litA.equals(litB)) {
+    return 0;
+  }
+  return isLowerThan(litA, litB, typeDiscoveryCallback, typeCache, enableExtendedXSDTypes) === isAscending ? -1 : 1;
+}
+
+function isLowerThan(litA: RDF.Term, litB: RDF.Term,
+  typeDiscoveryCallback?: SuperTypeCallback, typeCache?: TypeCache, enableExtendedXSDTypes?: boolean): boolean {
   const openWorldType: ISuperTypeProvider = {
     discoverer: typeDiscoveryCallback || (() => 'term'),
     cache: typeCache || new LRUCache(),
   };
   const termTransformer = new TermTransformer(openWorldType, enableExtendedXSDTypes || false);
-  if (litA && litA.termType === 'Literal' && litB && litB.termType === 'Literal') {
+  if (litA.termType === 'Literal' && litB.termType === 'Literal') {
     const myLitA = termTransformer.transformLiteral(litA);
     const myLitB = termTransformer.transformLiteral(litB);
-    return order(myLitA, myLitB, isAscending);
+    const aType = getValueClassName(myLitA.typedValue);
+    const bType = getValueClassName(myLitB.typedValue);
+    if (aType !== bType) {
+      return aType < bType;
+    }
+    return myLitA.typedValue < myLitB.typedValue;
   }
-  return 0;
-}
-
-// Effective ordering
-export function order(orderA: T.Literal<any>, orderB: T.Literal<any>, isAscending: boolean): -1 | 0 | 1 {
-  // If the two values have not the same typedValue type and, hence, are not comparable,
-  // we compare them using the typedValue type name.
-  const aType = getValueClassName(orderA.typedValue);
-  const bType = getValueClassName(orderB.typedValue);
-  if (aType !== bType) {
-    return aType > bType === isAscending ? 1 : -1;
-  }
-
-  if (orderA.typedValue === orderB.typedValue) {
-    return 0;
-  }
-  return orderA.typedValue > orderB.typedValue === isAscending ? 1 : -1;
+  // Order is not defined yet for other terms.
+  return true;
 }
 
 function getValueClassName(value: any): string {

--- a/lib/util/Ordering.ts
+++ b/lib/util/Ordering.ts
@@ -22,8 +22,21 @@ export function orderTypes(litA: RDF.Term | undefined, litB: RDF.Term | undefine
 
 // Effective ordering
 export function order(orderA: T.Literal<any>, orderB: T.Literal<any>, isAscending: boolean): -1 | 0 | 1 {
+  // If the two values have not the same typedValue type and, hence, are not comparable,
+  // we compare them using the typedValue type name.
+  const aType = getValueClassName(orderA.typedValue);
+  const bType = getValueClassName(orderB.typedValue);
+  if (aType !== bType) {
+    return aType > bType === isAscending ? 1 : -1;
+  }
+
   if (orderA.typedValue === orderB.typedValue) {
     return 0;
   }
   return orderA.typedValue > orderB.typedValue === isAscending ? 1 : -1;
+}
+
+function getValueClassName(value: any): string {
+  const type = typeof value;
+  return type === 'object' ? value.constructor.name : type;
 }

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -67,10 +67,6 @@ describe('ordering literals', () => {
     orderTestIsEqualBothSystems(int('11'), int('11'));
   });
 
-  it('integer decimal type identical', () => {
-    orderTestIsEqualBothSystems(int('11'), decimal('11.0'));
-  });
-
   it('string type identical', () => {
     orderTestIsEqualBothSystems(string('11'), string('11'));
   });

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -95,21 +95,19 @@ describe('ordering literals', () => {
   });
 
   it('mixed string integer comparison', () => {
-    const numA = string('11');
-    const numB = int('2');
-    const numD = int('11');
-    expect(orderTypes(numA, numB, true)).toEqual(1);
-    expect(orderTypes(numB, numA, true)).toEqual(-1);
-    expect(orderTypes(numA, numD, true)).toEqual(-1);
+    orderTestIsLowerBothSystems(int('11'), string('11'));
+    orderTestIsLowerBothSystems(int('2'), string('11'));
+  });
+
+  it('mixed string dateTime comparison', () => {
+    orderTestIsLowerBothSystems(dateTime('2000-01-01T00:00:00Z'), string('2000-01-01T00:00:00Z'));
+    orderTestIsLowerBothSystems(dateTime('2001-01-01T00:00:00Z'), string('2000-01-01T00:00:00Z'));
   });
 
   it('mixed unknown integer comparison', () => {
-    const numA = int('1');
-    const numB = decimal('011');
-    const numC = DF.literal('011', DF.namedNode('https://example.org/some-decimal'));
-    expect(orderTypes(numA, numB, true)).toEqual(-1);
-    expect(orderTypes(numB, numC, true)).toEqual(-1);
-    expect(orderTypes(numA, numC, true)).toEqual(-1);
+    orderTestIsLowerBothSystems(int('1'), decimal('011'));
+    orderTestIsLowerBothSystems(int('1'), DF.literal('011', DF.namedNode('https://example.org/some-decimal')));
+    orderTestIsLowerBothSystems(decimal('011'), DF.literal('011', DF.namedNode('https://example.org/some-decimal')));
   });
 
   it('handles unknown extended types as basic literals', () => {

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -5,28 +5,31 @@ import { DataFactory } from 'rdf-data-factory';
 import { TypeURL, TypeURL as DT } from '../../../lib/util/Consts';
 import { orderTypes } from '../../../lib/util/Ordering';
 import type { SuperTypeCallback, TypeCache } from '../../../lib/util/TypeHandling';
-import JestMatchers = jest.JestMatchers;
 
 const DF = new DataFactory();
 
-function int(value: string, dt?: string): RDF.Literal {
-  return DF.literal(value, DF.namedNode(dt || DT.XSD_INTEGER));
+function int(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_INTEGER));
 }
 
-function float(value: string, dt?: string): RDF.Literal {
-  return DF.literal(value, DF.namedNode(dt || DT.XSD_FLOAT));
+function float(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_FLOAT));
 }
 
-function decimal(value: string, dt?: string): RDF.Literal {
-  return DF.literal(value, DF.namedNode(dt || DT.XSD_DECIMAL));
+function decimal(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_DECIMAL));
 }
 
-function double(value: string, dt?: string): RDF.Literal {
-  return DF.literal(value, DF.namedNode(dt || DT.XSD_DOUBLE));
+function double(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_DOUBLE));
 }
 
-function string(value: string, dt?: string): RDF.Literal {
-  return DF.literal(value, DF.namedNode(dt || DT.XSD_STRING));
+function string(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_STRING));
+}
+
+function dateTime(value: string): RDF.Literal {
+  return DF.literal(value, DF.namedNode(DT.XSD_DATE_TIME));
 }
 
 function orderTestBothSystems(conditionCallBack: (res: -1 | 0 | 1) => void, litA: RDF.Term | undefined,
@@ -42,17 +45,26 @@ describe('ordering literals', () => {
     orderTestBothSystems(arg => expect(arg).toEqual(0), undefined, undefined, true);
     orderTestBothSystems(arg => expect(arg).toEqual(0), numB, undefined, true);
   });
+
   it('integers type identical', () => {
     const numA = int('11');
     const numB = int('11');
     orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
   });
+
+  it('integer decimal type identical', () => {
+    const numA = int('11');
+    const numB = decimal('11.0');
+    orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
+  });
+
   it('string type identical', () => {
     const numA = string('11');
     const numB = string('11');
     orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
     orderTestBothSystems(arg => expect(arg).toEqual(0), numB, numA, true);
   });
+
   it('string type comparison', () => {
     const numA = string('11');
     const numB = string('2');
@@ -91,6 +103,12 @@ describe('ordering literals', () => {
     orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
     orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
   });
+  it('dateTime type comparison', () => {
+    const numA = dateTime('2001-01-01T00:00:00Z');
+    const numB = dateTime('2000-01-01T00:00:00Z');
+    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
+    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
+  });
 
   it('mixed string integer comparison', () => {
     const numA = string('11');
@@ -101,11 +119,20 @@ describe('ordering literals', () => {
     orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numD, true);
   });
 
+  it('mixed unknown integer comparison', () => {
+    const numA = int('1');
+    const numB = decimal('011');
+    const numC = DF.literal('011', DF.namedNode('https://example.org/some-decimal'));
+    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, true);
+    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numC, true);
+    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numC, true);
+  });
+
   it('handles unknown extended types as basic literals', () => {
     const cache: TypeCache = new LRUCache();
-    const someType = 'https://example.org/some-decimal';
-    const numA = decimal('11', someType);
-    const numB = decimal('2', someType);
+    const someType = DF.namedNode('https://example.org/some-decimal');
+    const numA = DF.literal('11', someType);
+    const numB = DF.literal('2', someType);
     orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, true, undefined, cache);
     orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, true, undefined, cache);
     orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, false, undefined, cache);
@@ -115,9 +142,9 @@ describe('ordering literals', () => {
   it('handles extended types', () => {
     const discover: SuperTypeCallback = unknownType => TypeURL.XSD_DECIMAL;
     const cache: TypeCache = new LRUCache();
-    const someType = 'https://example.org/some-decimal';
-    const numA = decimal('11', someType);
-    const numB = decimal('2', someType);
+    const someType = DF.namedNode('https://example.org/some-decimal');
+    const numA = DF.literal('11', someType);
+    const numB = DF.literal('2', someType);
     expect(orderTypes(numA, numB, true, discover, cache, true)).toEqual(1);
     expect(orderTypes(numB, numA, true, discover, cache, true)).toEqual(-1);
     expect(orderTypes(numA, numB, false, discover, cache, true)).toEqual(-1);

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -89,6 +89,14 @@ describe('ordering literals', () => {
   it('dateTime type comparison', () => {
     orderTestIsLowerBothSystems(dateTime('2000-01-01T00:00:00Z'), dateTime('2001-01-01T00:00:00Z'));
   });
+  it('langString type comparison', () => {
+    orderTestIsLowerBothSystems(DF.literal('a', 'de'), DF.literal('a', 'en'));
+    orderTestIsLowerBothSystems(DF.literal('a', 'en'), DF.literal('b', 'en'));
+  });
+  it('boolean type comparison', () => {
+    const bool = DF.namedNode(DT.XSD_BOOLEAN);
+    orderTestIsLowerBothSystems(DF.literal('false', bool), DF.literal('true', bool));
+  });
 
   it('mixed string integer comparison', () => {
     orderTestIsLowerBothSystems(int('11'), string('11'));
@@ -102,8 +110,8 @@ describe('ordering literals', () => {
 
   it('mixed unknown integer comparison', () => {
     orderTestIsLowerBothSystems(int('1'), decimal('011'));
-    orderTestIsLowerBothSystems(int('1'), DF.literal('011', DF.namedNode('https://example.org/some-decimal')));
-    orderTestIsLowerBothSystems(decimal('011'), DF.literal('011', DF.namedNode('https://example.org/some-decimal')));
+    orderTestIsLowerBothSystems(int('1'), DF.literal('011', DF.namedNode(DT.XSD_ENTITY)));
+    orderTestIsLowerBothSystems(decimal('011'), DF.literal('011', DF.namedNode(DT.XSD_ENTITY)));
   });
 
   it('handles unknown extended types as basic literals', () => {
@@ -115,5 +123,16 @@ describe('ordering literals', () => {
     const discover: SuperTypeCallback = _ => TypeURL.XSD_DECIMAL;
     const someType = DF.namedNode('https://example.org/some-decimal');
     orderTestIsLower(DF.literal('2', someType), DF.literal('11', someType), discover, true);
+  });
+
+  it('custom literals comparison', () => {
+    const dt1 = DF.namedNode('http://example.org/dt1');
+    const dt2 = DF.namedNode('http://example.org/dt2');
+    orderTestIsLowerBothSystems(DF.literal('a', dt1), DF.literal('b', dt1));
+    orderTestIsLowerBothSystems(DF.literal('b', dt1), DF.literal('a', dt2));
+  });
+
+  it('invalid literals comparison', () => {
+    orderTestIsLowerBothSystems(dateTime('a'), dateTime('b'));
   });
 });

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -1,10 +1,9 @@
 import type * as RDF from '@rdfjs/types';
-import * as LRUCache from 'lru-cache';
 import { DataFactory } from 'rdf-data-factory';
 
 import { TypeURL, TypeURL as DT } from '../../../lib/util/Consts';
 import { orderTypes } from '../../../lib/util/Ordering';
-import type { SuperTypeCallback, TypeCache } from '../../../lib/util/TypeHandling';
+import type { SuperTypeCallback } from '../../../lib/util/TypeHandling';
 
 const DF = new DataFactory();
 
@@ -32,122 +31,95 @@ function dateTime(value: string): RDF.Literal {
   return DF.literal(value, DF.namedNode(DT.XSD_DATE_TIME));
 }
 
-function orderTestBothSystems(conditionCallBack: (res: -1 | 0 | 1) => void, litA: RDF.Term | undefined,
-  litB: RDF.Term | undefined, isAscending: boolean, typeDiscoveryCallback?: SuperTypeCallback, typeCache?: TypeCache) {
-  conditionCallBack(orderTypes(litA, litB, isAscending, typeDiscoveryCallback, typeCache, false));
-  conditionCallBack(orderTypes(litA, litB, isAscending, typeDiscoveryCallback, typeCache, true));
+function orderTestIsLower(litA: RDF.Term | undefined, litB: RDF.Term | undefined,
+  typeDiscoveryCallback?: SuperTypeCallback, enableExtendedXSDTypes?: boolean) {
+  expect(orderTypes(litA, litB, true, typeDiscoveryCallback, undefined, enableExtendedXSDTypes)).toEqual(-1);
+  expect(orderTypes(litA, litB, false, typeDiscoveryCallback, undefined, enableExtendedXSDTypes)).toEqual(1);
+  expect(orderTypes(litB, litA, true, typeDiscoveryCallback, undefined, enableExtendedXSDTypes)).toEqual(1);
+  expect(orderTypes(litB, litA, false, typeDiscoveryCallback, undefined, enableExtendedXSDTypes)).toEqual(-1);
+}
+
+function orderTestIsLowerBothSystems(litA: RDF.Term | undefined, litB: RDF.Term | undefined,
+  typeDiscoveryCallback?: SuperTypeCallback) {
+  orderTestIsLower(litA, litB, typeDiscoveryCallback, false);
+  orderTestIsLower(litA, litB, typeDiscoveryCallback, true);
+}
+
+function orderTestIsEqual(litA: RDF.Term | undefined, litB: RDF.Term | undefined, enableExtendedXSDTypes?: boolean) {
+  expect(orderTypes(litA, litB, true, undefined, undefined, enableExtendedXSDTypes)).toEqual(0);
+  expect(orderTypes(litA, litB, false, undefined, undefined, enableExtendedXSDTypes)).toEqual(0);
+  expect(orderTypes(litB, litA, true, undefined, undefined, enableExtendedXSDTypes)).toEqual(0);
+  expect(orderTypes(litB, litA, false, undefined, undefined, enableExtendedXSDTypes)).toEqual(0);
+}
+
+function orderTestIsEqualBothSystems(litA: RDF.Term | undefined, litB: RDF.Term | undefined) {
+  orderTestIsEqual(litA, litB, false);
+  orderTestIsEqual(litA, litB, true);
 }
 
 describe('ordering literals', () => {
   it('undefined passed to ordertypes', () => {
-    const numB = int('11');
-    orderTestBothSystems(arg => expect(arg).toEqual(0), undefined, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(0), undefined, undefined, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(0), numB, undefined, true);
+    orderTestIsEqualBothSystems(undefined, int('11'));
+    orderTestIsEqualBothSystems(undefined, undefined); // eslint-disable-line unicorn/no-useless-undefined
   });
 
   it('integers type identical', () => {
-    const numA = int('11');
-    const numB = int('11');
-    orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
+    orderTestIsEqualBothSystems(int('11'), int('11'));
   });
 
   it('integer decimal type identical', () => {
-    const numA = int('11');
-    const numB = decimal('11.0');
-    orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
+    orderTestIsEqualBothSystems(int('11'), decimal('11.0'));
   });
 
   it('string type identical', () => {
-    const numA = string('11');
-    const numB = string('11');
-    orderTestBothSystems(arg => expect(arg).toEqual(0), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(0), numB, numA, true);
+    orderTestIsEqualBothSystems(string('11'), string('11'));
   });
 
   it('string type comparison', () => {
-    const numA = string('11');
-    const numB = string('2');
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, false);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, false);
+    orderTestIsLowerBothSystems(string('11'), string('2'));
   });
   it('integer type comparison', () => {
-    const numA = int('11');
-    const numB = int('2');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, false);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, false);
+    orderTestIsLowerBothSystems(int('2'), int('11'));
   });
   it('double type comparison', () => {
-    const numA = double('11');
-    const numB = double('2');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, false);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, false);
+    orderTestIsLowerBothSystems(double('2'), double('11'));
   });
   it('decimal type comparison', () => {
-    const numA = decimal('11');
-    const numB = decimal('2');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, false);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, false);
+    orderTestIsLowerBothSystems(decimal('2'), decimal('11'));
   });
   it('float type comparison', () => {
-    const numA = float('11');
-    const numB = float('2');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
+    orderTestIsLowerBothSystems(float('2'), float('11'));
   });
   it('dateTime type comparison', () => {
-    const numA = dateTime('2001-01-01T00:00:00Z');
-    const numB = dateTime('2000-01-01T00:00:00Z');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
+    orderTestIsLowerBothSystems(dateTime('2000-01-01T00:00:00Z'), dateTime('2001-01-01T00:00:00Z'));
   });
 
   it('mixed string integer comparison', () => {
     const numA = string('11');
     const numB = int('2');
     const numD = int('11');
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numD, true);
+    expect(orderTypes(numA, numB, true)).toEqual(1);
+    expect(orderTypes(numB, numA, true)).toEqual(-1);
+    expect(orderTypes(numA, numD, true)).toEqual(-1);
   });
 
   it('mixed unknown integer comparison', () => {
     const numA = int('1');
     const numB = decimal('011');
     const numC = DF.literal('011', DF.namedNode('https://example.org/some-decimal'));
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numC, true);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numC, true);
+    expect(orderTypes(numA, numB, true)).toEqual(-1);
+    expect(orderTypes(numB, numC, true)).toEqual(-1);
+    expect(orderTypes(numA, numC, true)).toEqual(-1);
   });
 
   it('handles unknown extended types as basic literals', () => {
-    const cache: TypeCache = new LRUCache();
     const someType = DF.namedNode('https://example.org/some-decimal');
-    const numA = DF.literal('11', someType);
-    const numB = DF.literal('2', someType);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numA, numB, true, undefined, cache);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numB, numA, true, undefined, cache);
-    orderTestBothSystems(arg => expect(arg).toEqual(1), numA, numB, false, undefined, cache);
-    orderTestBothSystems(arg => expect(arg).toEqual(-1), numB, numA, false, undefined, cache);
+    orderTestIsLowerBothSystems(DF.literal('11', someType), DF.literal('2', someType));
   });
 
   it('handles extended types', () => {
-    const discover: SuperTypeCallback = unknownType => TypeURL.XSD_DECIMAL;
-    const cache: TypeCache = new LRUCache();
+    const discover: SuperTypeCallback = _ => TypeURL.XSD_DECIMAL;
     const someType = DF.namedNode('https://example.org/some-decimal');
-    const numA = DF.literal('11', someType);
-    const numB = DF.literal('2', someType);
-    expect(orderTypes(numA, numB, true, discover, cache, true)).toEqual(1);
-    expect(orderTypes(numB, numA, true, discover, cache, true)).toEqual(-1);
-    expect(orderTypes(numA, numB, false, discover, cache, true)).toEqual(-1);
-    expect(orderTypes(numB, numA, false, discover, cache, true)).toEqual(1);
+    orderTestIsLower(DF.literal('2', someType), DF.literal('11', someType), discover, true);
   });
 });


### PR DESCRIPTION
Before, if the two compared literals had `typedValue`s for which comparison was not supported by JavaScript, the first argument was always considered as lower than the second.

In this pull request, we compare first the kind of literals using buckets ("number", "string"...). If the two literals are in the same bucket, we proceed to the actual comparison.
If not, we compare the literals using the bucket identifier.
We do that instead of comparing directly the datatypes to avoid problems like `"xsd:decimal"` < `"xsd:entity"` < `"xsd:integer"` even if some decimals should be lower than integers.

This PR also simplifies the ordering tests to make sure all combinations of argument order and ascending/descending expectation are tested.

This PR removes the public Ordering.order that was completely unused.

The diffs are more readable if read commit by commit.

This is a first step to solve comunica/comunica#892