### PR TITLE
Improves function tests code coverage

### DIFF
--- a/lib/expressions/Term.ts
+++ b/lib/expressions/Term.ts
@@ -194,6 +194,16 @@ export class DoubleLiteral extends NumericLiteral {
   }
 
   protected specificFormatter(val: number): string {
+    if (!Number.isFinite(val)) {
+      if (val > 0) {
+        return 'INF';
+      }
+      if (val < 0) {
+        return '-INF';
+      }
+      return 'NaN';
+    }
+
     const jsExponential = val.toExponential();
     const [ jsMantisse, jsExponent ] = jsExponential.split('e');
 

--- a/lib/functions/Core.ts
+++ b/lib/functions/Core.ts
@@ -159,11 +159,6 @@ function defaultArityCheck(arity: number): (args: E.Expression[]) => boolean {
       return true;
     }
 
-    // If the function has overloaded arity, the actual arity needs to be present.
-    if (Array.isArray(arity)) {
-      return arity.includes(args.length);
-    }
-
     return args.length === arity;
   };
 }

--- a/lib/functions/Helpers.ts
+++ b/lib/functions/Helpers.ts
@@ -12,7 +12,6 @@ import type { MainNumericSparqlType } from '../util/Consts';
 import * as C from '../util/Consts';
 import { TypeAlias, TypeURL } from '../util/Consts';
 import * as Err from '../util/Errors';
-import { isInternalSubType } from '../util/TypeHandling';
 import type { ExperimentalArgumentType } from './Core';
 import { LegacyTree } from './LegacyTree';
 import type { ImplementationFunction } from './OverloadTree';
@@ -312,32 +311,20 @@ export function bool(val: boolean): E.BooleanLiteral {
   return new E.BooleanLiteral(val);
 }
 
-export function integer(num: number, dt?: C.KnownLiteralTypes): E.IntegerLiteral {
-  if (dt && !isInternalSubType(dt, TypeURL.XSD_INTEGER)) {
-    throw new Error('apple');
-  }
-  return new E.IntegerLiteral(num, dt);
+export function integer(num: number): E.IntegerLiteral {
+  return new E.IntegerLiteral(num);
 }
 
-export function decimal(num: number, dt?: C.KnownLiteralTypes): E.DecimalLiteral {
-  if (dt && !isInternalSubType(dt, TypeURL.XSD_DECIMAL)) {
-    throw new Error('apple');
-  }
-  return new E.DecimalLiteral(num, dt);
+export function decimal(num: number): E.DecimalLiteral {
+  return new E.DecimalLiteral(num);
 }
 
-export function float(num: number, dt?: C.KnownLiteralTypes): E.FloatLiteral {
-  if (dt && !isInternalSubType(dt, TypeURL.XSD_FLOAT)) {
-    throw new Error('apple');
-  }
-  return new E.FloatLiteral(num, dt);
+export function float(num: number): E.FloatLiteral {
+  return new E.FloatLiteral(num);
 }
 
-export function double(num: number, dt?: C.KnownLiteralTypes): E.DoubleLiteral {
-  if (dt && !isInternalSubType(dt, TypeURL.XSD_DOUBLE)) {
-    throw new Error('apple');
-  }
-  return new E.DoubleLiteral(num, dt);
+export function double(num: number): E.DoubleLiteral {
+  return new E.DoubleLiteral(num);
 }
 
 export function string(str: string): E.StringLiteral {

--- a/lib/util/Parsing.ts
+++ b/lib/util/Parsing.ts
@@ -14,7 +14,7 @@ export function parseXSDFloat(value: string): number | undefined {
     if (value === 'NaN') {
       return Number.NaN;
     }
-    if (value === 'INF') {
+    if (value === 'INF' || value === '+INF') {
       return Number.POSITIVE_INFINITY;
     }
     if (value === '-INF') {

--- a/test/integration/functions/XPathConstructors.test.ts
+++ b/test/integration/functions/XPathConstructors.test.ts
@@ -60,6 +60,10 @@ describe('evaluation of XPath constructors', () => {
         "-7.875"^^xsd:float = "-7.875"^^xsd:float'
         "2.5"^^xsd:decimal = "2.5"^^xsd:float'
         "-2.5"^^xsd:decimal = "-2.5"^^xsd:float'
+        "NaN" = "NaN"^^xsd:float'
+        "INF" = "INF"^^xsd:float'
+        "+INF" = "INF"^^xsd:float'
+        "-INF" = "-INF"^^xsd:float'
       `,
       errorTable: `
         "http://example.org/z"^^xsd:string = ''
@@ -67,6 +71,7 @@ describe('evaluation of XPath constructors', () => {
         "2002-10-10T17:00:00Z"^^xsd:string = ''
         "true"^^xsd:string = ''
         "false"^^xsd:string = ''
+        "foo"^^xsd:float = ''
       `,
     });
   });
@@ -104,6 +109,10 @@ describe('evaluation of XPath constructors', () => {
         "-7.875"^^xsd:float = "-7.875E0"^^xsd:double
         "2.5"^^xsd:decimal = "2.5E0"^^xsd:double
         "-2.5"^^xsd:decimal = "-2.5E0"^^xsd:double
+        "NaN" = "NaN"^^xsd:double
+        "INF" = "INF"^^xsd:double
+        "+INF" = "INF"^^xsd:double
+        "-INF" = "-INF"^^xsd:double
       `,
       errorTable: `
         "http://example.org/z"^^xsd:string = ''
@@ -111,6 +120,7 @@ describe('evaluation of XPath constructors', () => {
         "2002-10-10T17:00:00Z"^^xsd:string = ''
         "true"^^xsd:string = ''
         "false"^^xsd:string = ''
+        "foo"^^xsd:double = ''
       `,
     });
   });
@@ -160,6 +170,10 @@ describe('evaluation of XPath constructors', () => {
         "2002-10-10T17:00:00Z"^^xsd:string = ''
         "true"^^xsd:string = ''
         "false"^^xsd:string = ''
+        "foo"^^xsd:decimal = ''
+        "NaN"^^xsd:double = ''
+        "+INF"^^xsd:double = ''
+        "-INF"^^xsd:double = ''
       `,
     });
   });
@@ -202,6 +216,10 @@ describe('evaluation of XPath constructors', () => {
         "2002-10-10T17:00:00Z"^^xsd:string = ''
         "false"^^xsd:string = ''
         "true"^^xsd:string = ''
+        "foo"^^xsd:integer = ''
+        "NaN"^^xsd:double = ''
+        "+INF"^^xsd:double = ''
+        "-INF"^^xsd:double = ''
       `,
     });
   });
@@ -212,7 +230,13 @@ describe('evaluation of XPath constructors', () => {
       notation: Notation.Function,
       operation: 'xsd:dateTime',
       testTable: `
+        "1999-03-17T06:00:00Z"^^xsd:dateTime = "1999-03-17T06:00:00Z"^^xsd:dateTime
         "1999-03-17T06:00:00Z" = "1999-03-17T06:00:00Z"^^xsd:dateTime
+      `,
+      errorTable: `
+        "foo" = ''
+        "1234567789"^^xsd:integer = ''
+        "foo"^^xsd:dateTime = ''
       `,
     });
   });
@@ -256,6 +280,7 @@ describe('evaluation of XPath constructors', () => {
         "1.5"^^xsd:string = ''
         "1E0"^^xsd:string = ''
         "2002-10-10T17:00:00Z"^^xsd:string = ''
+        "foo"^^xsd:boolean = ''
       `,
     });
   });

--- a/test/integration/functions/hash.test.ts
+++ b/test/integration/functions/hash.test.ts
@@ -1,0 +1,74 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('hash functions', () => {
+  describe('evaluation of \'md5\' like', () => {
+    runTestTable({
+      arity: 1,
+      operation: 'md5',
+      notation: Notation.Function,
+      testTable: `
+        "foo" = "acbd18db4cc2f85cedef654fccc4a4d8"
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+
+  describe('evaluation of \'sha1\' like', () => {
+    runTestTable({
+      arity: 1,
+      operation: 'sha1',
+      notation: Notation.Function,
+      testTable: `
+        "foo" = "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+
+  describe('evaluation of \'sha256\' like', () => {
+    runTestTable({
+      arity: 1,
+      operation: 'sha256',
+      notation: Notation.Function,
+      testTable: `
+        "foo" = "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+
+  describe('evaluation of \'sha384\' like', () => {
+    runTestTable({
+      arity: 1,
+      operation: 'sha384',
+      notation: Notation.Function,
+      testTable: `
+        "foo" = "98c11ffdfdd540676b1a137cb1a22b2a70350c9a44171d6b1180c6be5cbb2ee3f79d532c8a1dd9ef2e8e08e752a3babb"
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+
+  describe('evaluation of \'sha512\' like', () => {
+    runTestTable({
+      arity: 1,
+      operation: 'sha512',
+      notation: Notation.Function,
+      testTable: `
+        "foo" = "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+});

--- a/test/integration/functions/onRDFterms.test.ts
+++ b/test/integration/functions/onRDFterms.test.ts
@@ -1,3 +1,4 @@
+import { bool } from '../../util/Aliases';
 import { Notation } from '../../util/TestTable';
 import { runTestTable } from '../../util/utils';
 
@@ -28,6 +29,9 @@ describe('evaluation of functions on RDF terms', () => {
         "a"@fr = "fr"
         "a" = ""
       `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
     });
   });
 
@@ -37,10 +41,69 @@ describe('evaluation of functions on RDF terms', () => {
       notation: Notation.Function,
       operation: 'datatype',
       testTable: `
-      "3"^^xsd:integer = http://www.w3.org/2001/XMLSchema#integer
-      "a"^^xsd:string = http://www.w3.org/2001/XMLSchema#string
-      '"plain literal"'  = http://www.w3.org/2001/XMLSchema#string
-      "3"^^xsd:anyURI = http://www.w3.org/2001/XMLSchema#anyURI
+        "3"^^xsd:integer = http://www.w3.org/2001/XMLSchema#integer
+        "a"^^xsd:string = http://www.w3.org/2001/XMLSchema#string
+        '"plain literal"'  = http://www.w3.org/2001/XMLSchema#string
+        "3"^^xsd:anyURI = http://www.w3.org/2001/XMLSchema#anyURI
+      `,
+      errorTable: `
+        <http://example.com> = 'Argument types not valid for operator'
+      `,
+    });
+  });
+
+  describe('like \'isIRI\' receiving', () => {
+    runTestTable({
+      arity: 1,
+      aliases: bool,
+      notation: Notation.Function,
+      operation: 'isIRI',
+      testTable: `
+        <http://example.com> = true
+        "foo" = false
+      `,
+    });
+  });
+
+  describe('like \'isBlank\' receiving', () => {
+    runTestTable({
+      arity: 1,
+      aliases: bool,
+      notation: Notation.Function,
+      operation: 'isBlank',
+      testTable: `
+        <http://example.com> = false
+        "foo" = false
+      `,
+    });
+  });
+
+  describe('like \'isLiteral\' receiving', () => {
+    runTestTable({
+      arity: 1,
+      aliases: bool,
+      notation: Notation.Function,
+      operation: 'isLiteral',
+      testTable: `
+        <http://example.com> = false
+        "foo" = true
+        "foo"@fr = true
+      `,
+    });
+  });
+
+  describe('like \'iri\' receiving', () => {
+    runTestTable({
+      arity: 1,
+      notation: Notation.Function,
+      operation: 'iri',
+      testTable: `
+      <http://example.com> = http://example.com
+      "http://example.com" = http://example.com
+      `,
+      errorTable: `
+        "foo" = 'Found invalid relative IRI'
+        1 = 'Argument types not valid for operator'
       `,
     });
   });

--- a/test/integration/functions/onStrings.test.ts
+++ b/test/integration/functions/onStrings.test.ts
@@ -45,6 +45,60 @@ describe('string functions', () => {
     });
   });
 
+  describe('evaluation of \'strstarts\' like', () => {
+    runTestTable({
+      arity: 2,
+      operation: 'strstarts',
+      notation: Notation.Function,
+      aliases: bool,
+      testTable: `
+       "ab" "a" = true
+       "ab" "c" = false
+       "ab"@en "a"@en = true
+       "ab"@en "c"@en = false
+      `,
+      errorTable: `
+       "ab"@en "a"@fr = 'Operation on incompatible language literals'
+      `,
+    });
+  });
+
+  describe('evaluation of \'strends\' like', () => {
+    runTestTable({
+      arity: 2,
+      operation: 'strends',
+      notation: Notation.Function,
+      aliases: bool,
+      testTable: `
+       "ab" "b" = true
+       "ab" "c" = false
+       "ab"@en "b"@en = true
+       "ab"@en "c"@en = false
+      `,
+      errorTable: `
+       "ab"@en "b"@fr = 'Operation on incompatible language literals'
+      `,
+    });
+  });
+
+  describe('evaluation of \'contains\' like', () => {
+    runTestTable({
+      arity: 2,
+      operation: 'contains',
+      notation: Notation.Function,
+      aliases: bool,
+      testTable: `
+       "aa" "a" = true
+       "aa" "b" = false
+       "aa"@en "a"@en = true
+       "aa"@en "b"@en = false
+      `,
+      errorTable: `
+       "aa"@en "a"@fr = 'Operation on incompatible language literals'
+      `,
+    });
+  });
+
   // TODO: Add errors for when non BCP47 strings are passed
   describe('evaluation of \'langMatches\' like', () => {
     runTestTable({
@@ -62,6 +116,7 @@ describe('string functions', () => {
        "de" "de-*-DE" = false
        "de-X-De" "de-*-DE" = false
        "de-Deva" "de-*-DE" = false
+       "de" "fr" = false
       `,
     });
   });
@@ -104,7 +159,7 @@ describe('string functions', () => {
   describe('evaluation of \'regex\' like', () => {
     // TODO: Test better
     runTestTable({
-      arity: 2,
+      arity: 'vary',
       operation: 'regex',
       notation: Notation.Function,
       aliases: bool,
@@ -112,6 +167,27 @@ describe('string functions', () => {
       "simple" "simple" = true
       "aaaaaa" "a" = true
       "simple" "blurgh" = false
+      "aaa" "a+" = true
+      "AAA" "a+" = false
+      "AAA" "a+" "i" = true
+      "a\\na" ".+" "s" = true
+      "a\\nb\\nc" "^b$" = false
+      "a\\nb\\nc" "^b$" "m" = true
+      `,
+    });
+  });
+
+  describe('evaluation of \'replace\' like', () => {
+    runTestTable({
+      arity: 'vary',
+      operation: 'replace',
+      notation: Notation.Function,
+      testTable: `
+      "baaab" "a+" "c" = "bcb"
+      "bAAAb" "a+" "c" = "bAAAb"
+      "bAAAb" "a+" "c" "i" = "bcb"
+      "baaab"@en "a+" "c" = "bcb"@en
+      "bAAAb"@en "a+" "c" "i" = "bcb"@en
       `,
     });
   });

--- a/test/integration/functions/op.addition.test.ts
+++ b/test/integration/functions/op.addition.test.ts
@@ -33,6 +33,19 @@ describe('evaluation of \'+\' like', () => {
       NaN    NaN    = NaN
       NaN    anyNum = NaN
       anyNum NaN    = NaN
+
+      0i 0d = 0d
+      0i 0f = 0f
+      0i "0"^^xsd:double = "0.0E0"^^xsd:double
+      0d 0i = 0d
+      0d 0f = 0f
+      0d "0"^^xsd:double = "0.0E0"^^xsd:double
+      0f 0i = 0f
+      0f 0d = 0f
+      0f "0"^^xsd:double = "0.0E0"^^xsd:double
+      "0"^^xsd:double 0i = "0.0E0"^^xsd:double
+      "0"^^xsd:double 0d = "0.0E0"^^xsd:double
+      "0"^^xsd:double 0f = "0.0E0"^^xsd:double
     `,
   });
   runTestTable({

--- a/test/integration/functions/op.bnode.test.ts
+++ b/test/integration/functions/op.bnode.test.ts
@@ -19,5 +19,8 @@ describe('evaluations of \'bnode\' with custom blank node generator function', (
     "" = _:bcd
     "hello" = _:hellocd
     `,
+    errorTable: `
+    1 = 'Argument types not valid for operator'
+    `,
   });
 });

--- a/test/integration/functions/op.bound.test.ts
+++ b/test/integration/functions/op.bound.test.ts
@@ -1,0 +1,44 @@
+import { BindingsFactory } from '@comunica/bindings-factory';
+import { DataFactory } from 'rdf-data-factory';
+import { expressionTypes, types } from 'sparqlalgebrajs/lib/algebra';
+import { SyncEvaluator } from '../../../lib/evaluators/SyncEvaluator';
+import { TypeURL as DT } from '../../../lib/util/Consts';
+import * as Err from '../../../lib/util/Errors';
+import { generalEvaluate } from '../../util/generalEvaluation';
+
+const DF = new DataFactory();
+const BF = new BindingsFactory();
+
+describe('evaluation of \'bound\'', () => {
+  it('\'bound\' on bounded variable returns true', async() => {
+    const evaluated = await generalEvaluate({
+      expression: 'SELECT * WHERE { ?s ?p ?o FILTER(BOUND(?s))}',
+      expectEquality: true,
+      bindings: BF.bindings([
+        [ DF.variable('s'), DF.namedNode('http://example.com') ],
+      ]),
+    });
+    expect(evaluated.asyncResult).toEqual(DF.literal('true', DF.namedNode(DT.XSD_BOOLEAN)));
+  });
+
+  it('\'bound\' on unbounded variable returns false', async() => {
+    const evaluated = await generalEvaluate({
+      expression: 'SELECT * WHERE { ?s ?p ?o FILTER(BOUND(?s))}', expectEquality: true,
+    });
+    expect(evaluated.asyncResult).toEqual(DF.literal('false', DF.namedNode(DT.XSD_BOOLEAN)));
+  });
+
+  it('\'bound\' on term returns error', async() => {
+    const evaluator = new SyncEvaluator({
+      type: types.EXPRESSION,
+      expressionType: expressionTypes.OPERATOR,
+      operator: 'bound',
+      args: [{
+        type: types.EXPRESSION,
+        expressionType: expressionTypes.TERM,
+        term: DF.namedNode('http://example.com'),
+      }],
+    });
+    expect(() => evaluator.evaluate(BF.bindings())).toThrow(Err.InvalidArgumentTypes);
+  });
+});

--- a/test/integration/functions/op.equality.test.ts
+++ b/test/integration/functions/op.equality.test.ts
@@ -96,4 +96,21 @@ describe('evaluation of \'=\'', () => {
       `,
     });
   });
+
+  describe('with other operands like', () => {
+    runTestTable({
+      ...config,
+      testTable: `
+        <http://example.com> <http://example.com> = true
+        <http://example.com/a> <http://example.com/b> = false
+        <http://example.com> 1 = false
+        1 <http://example.com> = false
+      `,
+      errorTable: `
+        1 true = 'Equality test for literals with unsupported datatypes'
+        1 aaa = 'Equality test for literals with unsupported datatypes'
+        1 earlyN = 'Equality test for literals with unsupported datatypes'
+      `,
+    });
+  });
 });

--- a/test/integration/functions/op.equality.test.ts
+++ b/test/integration/functions/op.equality.test.ts
@@ -110,7 +110,10 @@ describe('evaluation of \'=\'', () => {
         1 true = 'Equality test for literals with unsupported datatypes'
         1 aaa = 'Equality test for literals with unsupported datatypes'
         1 earlyN = 'Equality test for literals with unsupported datatypes'
-      `,
+        true "foo"^^xsd:boolean = 'Invalid lexical form'
+        "foo"^^xsd:boolean true = 'Invalid lexical form'
+        1 "foo"^^xsd:boolean = 'Invalid lexical form'
+        "foo"^^xsd:boolean 1 = 'Invalid lexical form'      `,
     });
   });
 });

--- a/test/integration/functions/op.in.test.ts
+++ b/test/integration/functions/op.in.test.ts
@@ -1,0 +1,37 @@
+import { bool, merge, numeric } from '../../util/Aliases';
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluations of \'IN\'', () => {
+  runTestTable({
+    operation: 'IN',
+    arity: 2,
+    notation: Notation.Infix,
+    aliases: merge(numeric, bool),
+    testTable: `
+      1 (2,1,3) = true
+      1 (2,1.0,3) = true
+      1 (2,3) = false
+      1 (?a,1) = true
+    `,
+    errorTable: `
+      1 (?a) = 'Some argument to IN errorred and none where equal.'
+    `,
+  });
+
+  runTestTable({
+    operation: 'NOT IN',
+    arity: 2,
+    notation: Notation.Infix,
+    aliases: merge(numeric, bool),
+    testTable: `
+      1 (2,1,3) = false
+      1 (2,1.0,3) = false
+      1 (2,3) = true
+      1 (?a,1) = false
+    `,
+    errorTable: `
+      1 (?a) = 'Some argument to IN errorred and none where equal.'
+    `,
+  });
+});

--- a/test/integration/functions/op.inequality.test.ts
+++ b/test/integration/functions/op.inequality.test.ts
@@ -81,4 +81,21 @@ describe('evaluation of \'!=\'', () => {
       `,
     });
   });
+
+  describe('with other operands like', () => {
+    runTestTable({
+      ...config,
+      testTable: `
+        <http://example.com> <http://example.com> = false
+        <http://example.com/a> <http://example.com/b> = true
+        <http://example.com> 1 = true
+        1 <http://example.com> = true
+      `,
+      errorTable: `
+        1 true = 'Equality test for literals with unsupported datatypes'
+        1 aaa = 'Equality test for literals with unsupported datatypes'
+        1 earlyN = 'Equality test for literals with unsupported datatypes'
+      `,
+    });
+  });
 });

--- a/test/integration/functions/op.sameTerm.test.ts
+++ b/test/integration/functions/op.sameTerm.test.ts
@@ -1,0 +1,24 @@
+import { bool, merge, numeric } from '../../util/Aliases';
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'sameTerm\'', () => {
+  runTestTable({
+    operation: 'sameTerm',
+    arity: 2,
+    notation: Notation.Function,
+    aliases: merge(numeric, bool),
+    testTable: `
+      <http://example.com> <http://example.com> = true
+      <http://example.com/é> <http://example.com/%A9> = false
+      1 1 = true
+      1 1.0 = false
+      true true = true
+      true "1"^^xsd:boolean = false
+      "a" "a" = true
+      "a" "a"^^xsd:string = true
+      "a"@en "a"@en = true
+      "a"@en "a"@en-US = false
+      `,
+  });
+});

--- a/test/integration/functions/op.unary.test.ts
+++ b/test/integration/functions/op.unary.test.ts
@@ -36,6 +36,9 @@ describe('unary functions', () => {
       notation: Notation.Prefix,
       testTable: `
         "3"^^xsd:integer     = "3"^^xsd:integer
+        "3"^^xsd:decimal     = "3"^^xsd:decimal
+        "3"^^xsd:float       = "3"^^xsd:float
+        "3"^^xsd:double      = "3"^^xsd:double
         "-10.5"^^xsd:decimal = "-10.5"^^xsd:decimal
         "NaN"^^xsd:float     = "NaN"^^xsd:float
       `,
@@ -50,6 +53,9 @@ describe('unary functions', () => {
       notation: Notation.Prefix,
       testTable: `
         "3"^^xsd:integer     = "-3"^^xsd:integer
+        "3"^^xsd:decimal     = "-3"^^xsd:decimal
+        "3"^^xsd:float       = "-3"^^xsd:float
+        "3"^^xsd:double      = "-3.0E0"^^xsd:double
         "0"^^xsd:integer     = "0"^^xsd:integer
         "-10.5"^^xsd:decimal = "10.5"^^xsd:decimal
         "NaN"^^xsd:float     = "NaN"^^xsd:float


### PR DESCRIPTION
All the lines in the `functions` directory should be covered except for the `uplus` function.

This PR also fixes float/doubles parsing and serialization of NaN and infinities.

It also removes some dead code in the helpers.