### PR TITLE
Min/Max: avoids not useful casts

### DIFF
--- a/lib/aggregators/Max.ts
+++ b/lib/aggregators/Max.ts
@@ -2,17 +2,17 @@ import type * as RDF from '@rdfjs/types';
 import { BaseAggregator } from './BaseAggregator';
 
 interface IExtremeState {
-  extremeValue: number; term: RDF.Literal;
+  extremeValue: number; term: RDF.Term;
 }
 export class Max extends BaseAggregator<IExtremeState> {
   public init(start: RDF.Term): IExtremeState {
     const { value } = this.extractValue(start);
-    return { extremeValue: value, term: <RDF.Literal>start };
+    return { extremeValue: value, term: start };
   }
 
   public put(state: IExtremeState, term: RDF.Term): IExtremeState {
     const extracted = this.extractValue(term);
-    if (extracted.value > state.extremeValue && term.termType === 'Literal') {
+    if (extracted.value > state.extremeValue) {
       return {
         extremeValue: extracted.value,
         term,

--- a/lib/aggregators/Min.ts
+++ b/lib/aggregators/Min.ts
@@ -2,17 +2,17 @@ import type * as RDF from '@rdfjs/types';
 import { BaseAggregator } from './BaseAggregator';
 
 interface IExtremeState {
-  extremeValue: number; term: RDF.Literal;
+  extremeValue: number; term: RDF.Term;
 }
 export class Min extends BaseAggregator<IExtremeState> {
   public init(start: RDF.Term): IExtremeState {
     const { value } = this.extractValue(start);
-    return { extremeValue: value, term: <RDF.Literal>start };
+    return { extremeValue: value, term: start };
   }
 
   public put(state: IExtremeState, term: RDF.Term): IExtremeState {
     const extracted = this.extractValue(term);
-    if (extracted.value < state.extremeValue && term.termType === 'Literal') {
+    if (extracted.value < state.extremeValue) {
       return {
         extremeValue: extracted.value,
         term,


### PR DESCRIPTION
removes also some `.termType === 'Literal'` checks that are redundant with `extractValue` calls.