### PR TITLE
Minor code cleanup

### DIFF
--- a/lib/aggregators/Sum.ts
+++ b/lib/aggregators/Sum.ts
@@ -20,8 +20,7 @@ export class Sum extends BaseAggregator<SumState> {
 
   public put(state: SumState, term: RDF.Term): SumState {
     const internalTerm = this.termToNumericOrError(term);
-    const sum = <E.NumericLiteral> this.summer.apply([ state, internalTerm ], this.sharedContext);
-    return sum;
+    return <E.NumericLiteral> this.summer.apply([ state, internalTerm ], this.sharedContext);
   }
 
   public result(state: SumState): RDF.Term {

--- a/lib/evaluators/evaluatorHelpers/BaseAggregateEvaluator.ts
+++ b/lib/evaluators/evaluatorHelpers/BaseAggregateEvaluator.ts
@@ -54,8 +54,6 @@ export abstract class BaseAggregateEvaluator {
    * The actual result method. When the first binding has been given, and the state
    * of the evaluators initialised. The .result API function will be replaced with this
    * function, which implements the behaviour we want.
-   *
-   * @param bindings the bindings to pass to the expression
    */
   protected __result(): RDF.Term {
     return this.aggregator.result(this.state);

--- a/lib/expressions/Term.ts
+++ b/lib/expressions/Term.ts
@@ -108,7 +108,7 @@ export class Literal<T extends { toString: () => string }> extends Term {
 
 export abstract class NumericLiteral extends Literal<number> {
   public readonly mainSparqlType: MainNumericSparqlType;
-  public constructor(
+  protected constructor(
     public typedValue: number,
     dataType: string,
     public strValue?: string,
@@ -226,7 +226,7 @@ export class BooleanLiteral extends Literal<boolean> {
   }
 
   public coerceEBV(): boolean {
-    return !!this.typedValue;
+    return this.typedValue;
   }
 }
 

--- a/lib/functions/LegacyTree.ts
+++ b/lib/functions/LegacyTree.ts
@@ -5,7 +5,6 @@ import type { ArgumentType, ExperimentalArgumentType } from './Core';
 import type { ImplementationFunction } from './OverloadTree';
 
 type SearchStack = LegacyTree[];
-type LegacyNodeCallback = (node: LegacyTree, argumentType: ArgumentType) => void;
 
 /**
  * Maps argument types on their specific implementation in a tree like structure.

--- a/lib/functions/SpecialFunctions.ts
+++ b/lib/functions/SpecialFunctions.ts
@@ -244,7 +244,7 @@ async function inRecursiveAsync(
   context: EvalContextAsync,
   results: (Error | false)[],
 ): PTerm {
-  const { args, mapping, evaluate, overloadCache } = context;
+  const { args, mapping, evaluate } = context;
   if (args.length === 0) {
     const noErrors = results.every(val => !val);
     return noErrors ? bool(false) : Promise.reject(new Err.InError(results));
@@ -269,7 +269,7 @@ function inRecursiveSync(
   context: EvalContextSync,
   results: (Error | false)[],
 ): Term {
-  const { args, mapping, evaluate, overloadCache } = context;
+  const { args, mapping, evaluate } = context;
   if (args.length === 0) {
     const noErrors = results.every(val => !val);
     if (noErrors) {

--- a/lib/util/Parsing.ts
+++ b/lib/util/Parsing.ts
@@ -78,9 +78,9 @@ export function parseXSDDateTime(value: string): ISplittedDate {
   const posT = value.indexOf('T');
   const date = posT >= 0 ? value.slice(0, Math.max(0, posT)) : value;
   const [ year, month, day ] = date.split('-');
-  let hours = '';
-  let minutes = '';
-  let seconds = '';
+  let hours = '00';
+  let minutes = '00';
+  let seconds = '00';
   let timezone = '';
   if (posT >= 0) {
     const timeAndTimeZone = value.slice(posT + 1);
@@ -88,11 +88,6 @@ export function parseXSDDateTime(value: string): ISplittedDate {
     [ hours, minutes, seconds ] = time.split(':');
     const timezoneOrNull = /([+Z-].*)/u.exec(timeAndTimeZone);
     timezone = timezoneOrNull ? timezoneOrNull[0] : '';
-  } else {
-    hours = '00';
-    minutes = '00';
-    seconds = '00';
-    timezone = '';
   }
   return { year, month, day, hours, minutes, seconds, timezone };
 }

--- a/test/spec/concat01.spec.ts
+++ b/test/spec/concat01.spec.ts
@@ -27,7 +27,7 @@ import * as Data from './_data';
  */
 
 describe('We should respect the concat01 spec', () => {
-  const { s1, s2, s3, s4, s5, s6, s7 } = Data.data();
+  const { s6, s7 } = Data.data();
   runTestTable({
     arity: 2,
     notation: Notation.Function,

--- a/test/util/TestTable.ts
+++ b/test/util/TestTable.ts
@@ -113,7 +113,6 @@ export class UnaryTable extends Table<[string, string]> {
       const { operation } = this.def;
       const aliases = this.def.aliases || {};
       it(`${this.format(operation, row)} should return ${result}`, async() => {
-        const rdfArg = aliases[arg] || arg;
         const expr = this.format(operation, <[string, string]> row.map(el => aliases[el] || el));
         await this.testExpression(expr, result);
       });


### PR DESCRIPTION
Applies some small cleanups suggested by IntelliJ:
- Makes abstract constructors protected
- Removes unused temporary variable
- Outdated comment
- Unused temporary type
- Unused variable initializations
- Removes not needed boolean casts