### PR TITLE
Fix cache search problem

### DIFF
--- a/lib/functions/OverloadTree.ts
+++ b/lib/functions/OverloadTree.ts
@@ -78,7 +78,7 @@ export class OverloadTree {
   public search(args: E.TermExpression[], superTypeProvider: ISuperTypeProvider,
     functionArgumentsCache: FunctionArgumentsCache):
     ImplementationFunction | undefined {
-    let cacheIter = functionArgumentsCache[this.identifier];
+    let cacheIter: IFunctionArgumentsCacheObj | undefined = functionArgumentsCache[this.identifier];
     let searchIndex = 0;
     while (searchIndex < args.length && cacheIter?.cache) {
       const term = args[searchIndex];
@@ -86,7 +86,7 @@ export class OverloadTree {
       cacheIter = cacheIter.cache[literalExpression ? literalExpression.dataType : term.termType];
       searchIndex++;
     }
-    if (searchIndex === args.length && cacheIter) {
+    if (searchIndex === args.length && cacheIter?.func) {
       return cacheIter.func;
     }
 

--- a/lib/functions/OverloadTree.ts
+++ b/lib/functions/OverloadTree.ts
@@ -115,7 +115,6 @@ export class OverloadTree {
     }
     // Calling a function with one argument but finding no implementation should return no implementation.
     // Not even the one with no arguments.
-    this.addToCache(functionArgumentsCache, args);
     return undefined;
   }
 
@@ -131,7 +130,7 @@ export class OverloadTree {
     for (const term of args) {
       const literalExpression = isLiteralTermExpression(term);
       const key = literalExpression ? literalExpression.dataType : term.termType;
-      cache.cache = {};
+      cache.cache = cache.cache || {};
       cache = getDefault(cache.cache, key);
     }
     cache.func = func;

--- a/test/unit/functions/OverloadTree.test.ts
+++ b/test/unit/functions/OverloadTree.test.ts
@@ -106,11 +106,30 @@ describe('OverloadTree', () => {
     expect(innerSpy).toHaveBeenCalled();
   });
 
-  it('will cache an undefined function', () => {
+  it('searches the cache arity aware', () => {
+    const apple = new StringLiteral('apple');
+    const one = new IntegerLiteral(1);
+    const two = new IntegerLiteral(2);
+    expect(sharedContext.functionArgumentsCache.substr).toBeUndefined();
+    expect(regularFunctions.substr.apply([ apple, one, two ], sharedContext).str()).toBe('ap');
+
+    expect(sharedContext.functionArgumentsCache.substr).toBeDefined();
+    const interestCache = sharedContext.functionArgumentsCache.substr
+      .cache![TypeURL.XSD_STRING].cache![TypeURL.XSD_INTEGER];
+    expect(interestCache.func).toBeUndefined();
+    expect(interestCache.cache![TypeURL.XSD_INTEGER]).toBeDefined();
+
+    expect(regularFunctions.substr.apply([ apple, one ], sharedContext).str()).toBe(String('apple'));
+    const interestCacheNew = sharedContext.functionArgumentsCache.substr
+      .cache![TypeURL.XSD_STRING].cache![TypeURL.XSD_INTEGER];
+    expect(interestCacheNew).toBeDefined();
+    expect(interestCacheNew.cache![TypeURL.XSD_INTEGER]).toBeDefined();
+  });
+
+  it('will not cache an undefined function', () => {
     const cache: FunctionArgumentsCache = {};
     const args = [ new StringLiteral('some str') ];
     emptyTree.search(args, sharedContext.superTypeProvider, cache);
-    expect(cache[emptyID]).not.toBeUndefined();
-    expect(cache[emptyID].cache![TypeURL.XSD_STRING]!.func).toBeUndefined();
+    expect(cache[emptyID]).toBeUndefined();
   });
 });


### PR DESCRIPTION
Running the spec tests of the Comunica repo showed something was wrong in the cache search for functions hanging multiple arity. This PR is a fix for this problem. 