### PR TITLE
Add SPARQL-star operators and comparison

### DIFF
--- a/lib/expressions/Expressions.ts
+++ b/lib/expressions/Expressions.ts
@@ -76,12 +76,12 @@ export type SpecialOperatorExpression = IExpressionProps & {
 
 // TODO: Create alias Term = TermExpression
 export function asTermType(type: string): TermType | undefined {
-  if (type === 'namedNode' || type === 'literal' || type === 'blankNode') {
+  if (type === 'namedNode' || type === 'literal' || type === 'blankNode' || type === 'quad') {
     return type;
   }
   return undefined;
 }
-export type TermType = 'namedNode' | 'literal' | 'blankNode';
+export type TermType = 'namedNode' | 'literal' | 'blankNode' | 'quad';
 export type TermExpression = IExpressionProps & {
   expressionType: ExpressionType.Term;
   termType: TermType;

--- a/lib/expressions/Term.ts
+++ b/lib/expressions/Term.ts
@@ -1,5 +1,6 @@
 import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
+import { TermTransformer } from '../transformers/TermTransformer';
 import * as C from '../util/Consts';
 import { TypeAlias, TypeURL } from '../util/Consts';
 
@@ -62,6 +63,47 @@ export class BlankNode extends Term {
 
   public toRDF(): RDF.Term {
     return this.value;
+  }
+}
+
+// Quads -----------------------------------------------------------------
+export class Quad extends Term {
+  public termType: TermType = 'quad';
+  private readonly transformer: TermTransformer;
+  private readonly valueTerm: RDF.BaseQuad;
+
+  public constructor(input: RDF.BaseQuad, superTypeProvider: ISuperTypeProvider) {
+    super();
+    this.transformer = new TermTransformer(superTypeProvider);
+    this.valueTerm = input;
+  }
+
+  public toRDF(): RDF.BaseQuad {
+    return this.valueTerm;
+  }
+
+  public get subject(): Term {
+    return this.transformer.transformRDFTermUnsafe(this.RDFsubject);
+  }
+
+  public get predicate(): Term {
+    return this.transformer.transformRDFTermUnsafe(this.RDFpredicate);
+  }
+
+  public get object(): Term {
+    return this.transformer.transformRDFTermUnsafe(this.RDFobject);
+  }
+
+  public get RDFsubject(): RDF.Term {
+    return this.toRDF().subject;
+  }
+
+  public get RDFpredicate(): RDF.Term {
+    return this.toRDF().predicate;
+  }
+
+  public get RDFobject(): RDF.Term {
+    return this.toRDF().object;
   }
 }
 

--- a/lib/functions/Helpers.ts
+++ b/lib/functions/Helpers.ts
@@ -5,7 +5,7 @@
 import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
 import type { ICompleteSharedContext } from '../evaluators/evaluatorHelpers/BaseExpressionEvaluator';
-import type { Literal, TermExpression } from '../expressions';
+import type { Literal, TermExpression, Quad } from '../expressions';
 import * as E from '../expressions';
 import { NonLexicalLiteral } from '../expressions';
 import * as C from '../util/Consts';
@@ -116,6 +116,15 @@ export class Builder {
       context => ([ term ]: [Term]) => op(context)(term),
       addInvalidHandling,
     );
+  }
+
+  public onTerm3(op: (context: ICompleteSharedContext) => (t1: Term, t2: Term, t3: Term) => Term): Builder {
+    return this.set([ 'term', 'term', 'term' ],
+      context => ([ t1, t2, t3 ]: [Term, Term, Term]) => op(context)(t1, t2, t3));
+  }
+
+  public onQuad1(op: (context: ICompleteSharedContext) => (term: Term & Quad) => Term): Builder {
+    return this.set([ 'quad' ], context => ([ term ]: [Term & Quad]) => op(context)(term));
   }
 
   public onLiteral1<T>(op: (context: ICompleteSharedContext) => (lit: E.Literal<T>) => Term,

--- a/lib/transformers/TermTransformer.ts
+++ b/lib/transformers/TermTransformer.ts
@@ -55,6 +55,8 @@ export class TermTransformer implements ITermTransformer {
         return new E.NamedNode(term.term.value);
       case 'BlankNode':
         return new E.BlankNode(term.term.value);
+      case 'Quad':
+        return new E.Quad(term.term, this.superTypeProvider);
       default:
         throw new Err.InvalidTermType(term);
     }

--- a/lib/util/Consts.ts
+++ b/lib/util/Consts.ts
@@ -168,6 +168,14 @@ export enum RegularOperator {
   // XPath Constructor functions
   // https://www.w3.org/TR/sparql11-query/#FunctionMapping
   // See Named Operators
+
+  // Functions for quoted triples
+  // https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#triple-function
+  TRIPLE = 'triple',
+  SUBJECT = 'subject',
+  PREDICATE = 'predicate',
+  OBJECT = 'object',
+  IS_TRIPLE = 'istriple',
 }
 
 export enum SpecialOperator {

--- a/lib/util/Errors.ts
+++ b/lib/util/Errors.ts
@@ -104,6 +104,15 @@ export class InvalidArgumentTypes extends ExpressionError {
 }
 
 /**
+ * Terms were being compared that are not supported.
+ */
+export class InvalidCompareArgumentTypes extends ExpressionError {
+  public constructor(public arg0: RDF.Term, public arg1: RDF.Term) {
+    super(`Compared argument types are supported: '${arg0.termType}' and '${arg1.termType}'`);
+  }
+}
+
+/**
  * An invalid typecast happened.
  */
 export class CastError<T> extends ExpressionError {

--- a/package.json
+++ b/package.json
@@ -81,11 +81,11 @@
     "bignumber.js": "^9.0.1",
     "hash.js": "^1.1.7",
     "lru-cache": "^6.0.0",
-    "rdf-data-factory": "^1.1.0",
-    "rdf-string": "^1.6.0",
+    "rdf-data-factory": "^1.1.2",
+    "rdf-string": "^1.6.3",
     "relative-to-absolute-iri": "^1.0.6",
     "spark-md5": "^3.0.1",
-    "sparqlalgebrajs": "^4.0.3",
+    "sparqlalgebrajs": "^4.2.0",
     "uuid": "^8.0.0"
   },
   "jest": {

--- a/test/integration/functions/op.equality.test.ts
+++ b/test/integration/functions/op.equality.test.ts
@@ -152,4 +152,21 @@ describe('evaluation of \'=\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', 'false' ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.greaterThen.test.ts
+++ b/test/integration/functions/op.greaterThen.test.ts
@@ -129,4 +129,26 @@ describe('evaluation of \'>\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+      ],
+    });
+    runTestTable({
+      ...config,
+      errorArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', `Compared argument types are supported: 'NamedNode' and 'NamedNode'` ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.greaterThenEqual.test.ts
+++ b/test/integration/functions/op.greaterThenEqual.test.ts
@@ -165,4 +165,26 @@ describe('evaluation of \'>=\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+      ],
+    });
+    runTestTable({
+      ...config,
+      errorArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', `Compared argument types are supported: 'NamedNode' and 'NamedNode'` ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.inequality.test.ts
+++ b/test/integration/functions/op.inequality.test.ts
@@ -149,4 +149,21 @@ describe('evaluation of \'!=\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', 'true' ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.istriple.test.ts
+++ b/test/integration/functions/op.istriple.test.ts
@@ -1,0 +1,16 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'ISTRIPLE\'', () => {
+  // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#istriple
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'ISTRIPLE',
+    testArray: [
+      [ '<< <ex:a> <ex:b> <ex:c> >>', '"true"^^xsd:boolean' ],
+      [ '"123"', '"false"^^xsd:boolean' ],
+      [ '<ex:abc>', '"false"^^xsd:boolean' ],
+    ],
+  });
+});

--- a/test/integration/functions/op.lesserThan.test.ts
+++ b/test/integration/functions/op.lesserThan.test.ts
@@ -134,4 +134,26 @@ describe('evaluation of \'<\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'false' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'false' ],
+      ],
+    });
+    runTestTable({
+      ...config,
+      errorArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', `Compared argument types are supported: 'NamedNode' and 'NamedNode'` ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.lesserThanEqual.test.ts
+++ b/test/integration/functions/op.lesserThanEqual.test.ts
@@ -172,4 +172,26 @@ describe('evaluation of \'<=\'', () => {
       `,
     });
   });
+
+  describe('with quoted triple operands like', () => {
+    // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-compare
+    runTestTable({
+      ...config,
+      testArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123.0 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< << <ex:a> <ex:b> 123 >> <ex:q> 999 >>', '<< << <ex:a> <ex:b> 123.0 >> <ex:q> 999 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123e0 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 9 >>', '<< <ex:a> <ex:b> 123 >>', 'true' ],
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:a> <ex:b> 9 >>', 'false' ],
+      ],
+    });
+    runTestTable({
+      ...config,
+      errorArray: [
+        [ '<< <ex:a> <ex:b> 123 >>', '<< <ex:c> <ex:d> 123 >>', `Compared argument types are supported: 'NamedNode' and 'NamedNode'` ],
+      ],
+    });
+  });
 });

--- a/test/integration/functions/op.object.test.ts
+++ b/test/integration/functions/op.object.test.ts
@@ -1,0 +1,23 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'OBJECT\'', () => {
+  // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#object
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'OBJECT',
+    testArray: [
+      [ '<< <ex:a> <ex:b> <ex:c> >>', 'ex:c' ],
+      [ '<< <ex:a2> <ex:b2> "123" >>', '"123"' ],
+    ],
+  });
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'OBJECT',
+    errorArray: [
+      [ '<ex:a>', `Argument types not valid for operator: '"object"' with '[{"expressionType":"term","value":"ex:a","termType":"namedNode"}]` ],
+    ],
+  });
+});

--- a/test/integration/functions/op.predicate.test.ts
+++ b/test/integration/functions/op.predicate.test.ts
@@ -1,0 +1,23 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'PREDICATE\'', () => {
+  // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#predicate
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'PREDICATE',
+    testArray: [
+      [ '<< <ex:a> <ex:b> <ex:c> >>', 'ex:b' ],
+      [ '<< <ex:a2> <ex:b2> "123" >>', 'ex:b2' ],
+    ],
+  });
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'PREDICATE',
+    errorArray: [
+      [ '<ex:a>', `Argument types not valid for operator: '"predicate"' with '[{"expressionType":"term","value":"ex:a","termType":"namedNode"}]` ],
+    ],
+  });
+});

--- a/test/integration/functions/op.subject.test.ts
+++ b/test/integration/functions/op.subject.test.ts
@@ -1,0 +1,23 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'SUBJECT\'', () => {
+  // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#subject
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'SUBJECT',
+    testArray: [
+      [ '<< <ex:a> <ex:b> <ex:c> >>', 'ex:a' ],
+      [ '<< <ex:a2> <ex:b2> "123" >>', 'ex:a2' ],
+    ],
+  });
+  runTestTable({
+    arity: 1,
+    notation: Notation.Function,
+    operation: 'SUBJECT',
+    errorArray: [
+      [ '<ex:a>', `Argument types not valid for operator: '"subject"' with '[{"expressionType":"term","value":"ex:a","termType":"namedNode"}]` ],
+    ],
+  });
+});

--- a/test/integration/functions/op.triple.test.ts
+++ b/test/integration/functions/op.triple.test.ts
@@ -1,0 +1,15 @@
+import { Notation } from '../../util/TestTable';
+import { runTestTable } from '../../util/utils';
+
+describe('evaluation of \'TRIPLE\'', () => {
+  // Originates from: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#triple-function
+  runTestTable({
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'TRIPLE',
+    testArray: [
+      [ '<ex:a>', '<ex:b>', '<ex:c>', '<< <ex:a> <ex:b> <ex:c> >>' ],
+      [ '<ex:a>', '<ex:b>', '"123"', '<< <ex:a> <ex:b> "123" >>' ],
+    ],
+  });
+});

--- a/test/integration/util/Ordering.test.ts
+++ b/test/integration/util/Ordering.test.ts
@@ -33,10 +33,8 @@ function dateTime(value: string): RDF.Literal {
 
 function orderTestIsLower(litA: RDF.Term | undefined, litB: RDF.Term | undefined,
   typeDiscoveryCallback?: SuperTypeCallback) {
-  expect(orderTypes(litA, litB, true, typeDiscoveryCallback)).toEqual(-1);
-  expect(orderTypes(litA, litB, false, typeDiscoveryCallback)).toEqual(1);
-  expect(orderTypes(litB, litA, true, typeDiscoveryCallback)).toEqual(1);
-  expect(orderTypes(litB, litA, false, typeDiscoveryCallback)).toEqual(-1);
+  expect(orderTypes(litA, litB, false, typeDiscoveryCallback)).toEqual(-1);
+  expect(orderTypes(litB, litA, false, typeDiscoveryCallback)).toEqual(1);
 }
 
 function genericOrderTestLower(litA: RDF.Term | undefined, litB: RDF.Term | undefined,
@@ -45,10 +43,8 @@ function genericOrderTestLower(litA: RDF.Term | undefined, litB: RDF.Term | unde
 }
 
 function orderTestIsEqual(litA: RDF.Term | undefined, litB: RDF.Term | undefined) {
-  expect(orderTypes(litA, litB, true)).toEqual(0);
-  expect(orderTypes(litA, litB, false)).toEqual(0);
-  expect(orderTypes(litB, litA, true)).toEqual(0);
-  expect(orderTypes(litB, litA, false)).toEqual(0);
+  expect(orderTypes(litA, litB)).toEqual(0);
+  expect(orderTypes(litB, litA)).toEqual(0);
 }
 
 describe('terms order', () => {
@@ -152,5 +148,20 @@ describe('terms order', () => {
 
   it('invalid literals comparison', () => {
     genericOrderTestLower(dateTime('a'), dateTime('b'));
+  });
+
+  it('quoted triples comparison', () => {
+    genericOrderTestLower(
+      DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:a'), DF.namedNode('ex:a')),
+      DF.quad(DF.namedNode('ex:b'), DF.namedNode('ex:b'), DF.namedNode('ex:b')),
+    );
+    genericOrderTestLower(
+      DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:a'), DF.namedNode('ex:a')),
+      DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:b'), DF.namedNode('ex:b')),
+    );
+    genericOrderTestLower(
+      DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:a'), DF.namedNode('ex:a')),
+      DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:a'), DF.namedNode('ex:b')),
+    );
   });
 });

--- a/test/util/generalEvaluation.ts
+++ b/test/util/generalEvaluation.ts
@@ -114,7 +114,7 @@ function syncCallbackWrapper(f: SyncExtensionFunctionCreator | undefined): Async
 }
 
 function parse(query: string) {
-  const sparqlQuery = translate(query);
+  const sparqlQuery = translate(query, { sparqlStar: true });
   // Extract filter expression from complete query
   return sparqlQuery.input.expression;
 }

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -3,7 +3,7 @@ import type { ICompleteSharedContext } from '../../lib/evaluators/evaluatorHelpe
 import type { AliasMap } from './Aliases';
 import type { GeneralEvaluationConfig } from './generalEvaluation';
 import type { Notation } from './TestTable';
-import { BinaryTable, UnaryTable, VariableTable } from './TestTable';
+import { ArrayTable, BinaryTable, UnaryTable, VariableTable } from './TestTable';
 
 export interface ITestTableConfigBase {
   /**
@@ -33,19 +33,31 @@ export type TestTableConfig = ITestTableConfigBase & {
    */
   testTable?: string;
   /**
+   * Test array that will check equality;
+   */
+  testArray?: string[][];
+  /**
    * TestTable that will check if a given error is thrown.
    * Result can be '' if the message doesn't need to be checked.
    */
   errorTable?: string;
+  /**
+   * Test array that will check if a given error is thrown.
+   * Result can be '' if the message doesn't need to be checked.
+   */
+  errorArray?: string[][];
 };
 
 export function runTestTable(arg: TestTableConfig): void {
-  if (!(arg.testTable || arg.errorTable)) {
+  if (!(arg.testTable || arg.testArray || arg.errorTable || arg.errorArray)) {
     // We throw this error and don't just say all is well because not providing a table is probably a user mistake.
-    throw new Error('Can not test if neither testTable or errorTable is provided');
+    throw new Error('Can not test if no testTable, testArray, or errorTable is provided');
   }
-  let testTable: UnaryTable | BinaryTable | VariableTable;
-  if (arg.arity === 1) {
+
+  let testTable: ArrayTable | UnaryTable | BinaryTable | VariableTable;
+  if (arg.testArray || arg.errorArray) {
+    testTable = new ArrayTable(arg);
+  } else if (arg.arity === 1) {
     testTable = new UnaryTable(arg);
   } else if (arg.arity === 2) {
     testTable = new BinaryTable(arg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,6 +3827,13 @@ rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1:
   dependencies:
     "@rdfjs/types" "*"
 
+rdf-data-factory@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz#d47550d2649d0d64f8cae3fcc9efae7a8a895d9a"
+  integrity sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==
+  dependencies:
+    "@rdfjs/types" "*"
+
 rdf-isomorphic@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz#cd6d433cd85bf79d903d5f0fdeea42a40eb27265"
@@ -3844,13 +3851,22 @@ rdf-js@^4.0.2:
   dependencies:
     "@rdfjs/types" "*"
 
-rdf-string@^1.6.0, rdf-string@^1.6.1:
+rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
+
+rdf-terms@^1.10.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
+  integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
 
 rdf-terms@^1.7.0:
   version "1.9.1"
@@ -4198,10 +4214,10 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.0.3:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz#054cd4dbbe9c2e2ecc345948fd5a7cfad1d475a4"
-  integrity sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==
+sparqlalgebrajs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz#b70945bdd2ab2897a0bc22adb804dd1a2b0ec98c"
+  integrity sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==
   dependencies:
     "@rdfjs/types" "*"
     "@types/sparqljs" "^3.1.3"
@@ -4210,14 +4226,15 @@ sparqlalgebrajs@^4.0.3:
     rdf-data-factory "^1.1.0"
     rdf-isomorphic "^1.3.0"
     rdf-string "^1.6.0"
-    sparqljs "^3.6.1"
+    rdf-terms "^1.10.0"
+    sparqljs "^3.7.1"
 
-sparqljs@^3.6.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.6.2.tgz#d8ddbe8a5b8cee5fbeab93d375e7379fef429aff"
-  integrity sha512-KQEJPaOMeeDpdYYuiFb3JEErRLL8XqX4G7sdhZyHC6Qn4+PEMUff/EjUGkwcJ6aCC0JCTIgxDpRdE3+GFXpdxw==
+sparqljs@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.1.tgz#5d121895d491d50214f2e38f2885a3a935b6c093"
+  integrity sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==
   dependencies:
-    rdf-data-factory "^1.1.1"
+    rdf-data-factory "^1.1.2"
 
 spawn-sync@^1.0.15:
   version "1.0.15"


### PR DESCRIPTION
Partially built on top of @jeswr's WIP PR from #161.

@jitsedesmet I changed the ordering logic quite a bit (the old version had a fundamental flaw where `>` was considered the opposite to `<`), so it might be good for you to check if I didn't break anything major (all unit and spec tests still pass).